### PR TITLE
Add macOS setup for maintained Boss CLI fork

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recruiting-copilot",
   "description": "AI 招聘副驾：梳理岗位真实要求、每日 Boss直聘+猎聘双通道寻源初筛打招呼、市场人才盘点、平台外简历评估、约面试（日程+视频会议+面试官）、台账与日报闭环。",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Viy Zhu"
   }

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@
 ## 前置条件（所有工具通用）
 
 1. [Node.js](https://nodejs.org) ≥ 20，本机装有 Chrome 或 Edge
-2. 安装两个招聘平台 CLI（驱动真实浏览器，用你自己的账号）：
+2. 运行依赖安装脚本（驱动真实浏览器，用你自己的账号）：
    ```bash
-   npm install -g @joohw/boss-cli @viyzhu/liepin-cli
+   sh skills/recruit-init/scripts/install-dependencies.sh
    ```
+   脚本默认安装 [`Viy1204/boss-cli`](https://github.com/Viy1204/boss-cli) 维护版，
+   因为它包含当前 Boss 前端的兼容与安全基线更新。macOS 上如果 npm 全局命令
+   不在 `PATH`，脚本会自动、可重复地更新 `~/.zprofile`。
 3. 各扫码登录一次（登录态持久化）：
    ```bash
    boss login
@@ -37,6 +40,7 @@
 ```bash
 git clone <本仓库地址>
 cd recruiting-copilot
+sh skills/recruit-init/scripts/install-dependencies.sh
 ```
 
 用你的 AI 工具打开这个目录，说：**"帮我初始化招聘工作区"**。

--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@
 ## 前置条件（所有工具通用）
 
 1. [Node.js](https://nodejs.org) ≥ 20，本机装有 Chrome 或 Edge
-2. 运行依赖安装脚本（驱动真实浏览器，用你自己的账号）：
-   ```bash
-   sh skills/recruit-init/scripts/install-dependencies.sh
-   ```
-   脚本默认安装 [`Viy1204/boss-cli`](https://github.com/Viy1204/boss-cli) 维护版，
+2. 在下方“安装与使用”步骤中运行依赖安装脚本。脚本默认安装
+   [`Viy1204/boss-cli`](https://github.com/Viy1204/boss-cli) 维护版，
    因为它包含当前 Boss 前端的兼容与安全基线更新。macOS 上如果 npm 全局命令
-   不在 `PATH`，脚本会自动、可重复地更新 `~/.zprofile`。
+   不在 `PATH`，脚本会自动、可重复地更新当前 shell 的配置文件
+   （zsh 为 `~/.zprofile`，bash 为 `~/.bash_profile`）。
 3. 各扫码登录一次（登录态持久化）：
    ```bash
    boss login

--- a/docs/plans/2026-07-14-macos-fork-installer-design.md
+++ b/docs/plans/2026-07-14-macos-fork-installer-design.md
@@ -9,7 +9,7 @@ Make first-time recruiting-copilot setup work on macOS without manual PATH repai
 Add `skills/recruit-init/scripts/install-dependencies.sh` as the public setup seam. It must:
 
 - require Node.js 20 or newer and npm;
-- install Boss CLI from `git+https://github.com/Viy1204/boss-cli.git#main` by default;
+- build Boss CLI from `git+https://github.com/Viy1204/boss-cli.git#main` by default;
 - allow `BOSS_CLI_SOURCE` to override that source;
 - install `@viyzhu/liepin-cli` from npm;
 - locate the npm global executable directory from `npm config get prefix`;
@@ -36,6 +36,10 @@ Shell tests exercise only public behavior:
 5. Check-only mode does not invoke npm installation.
 
 Tests use temporary HOME directories and fake `node`, `npm`, and `uname` executables; they never change the developer's actual shell profile or global packages.
+
+## Durable fork packaging
+
+Real-machine validation found that npm 11 can install a global Git dependency as a symbolic link into npm's temporary clone directory. A later npm operation may reuse that directory and remove the `boss` executable. The installer therefore shallow-clones the selected fork ref, runs `npm ci` and the TypeScript build, creates a package archive with `npm pack`, and installs that archive globally. It only removes the previous Boss package after the new archive has built successfully. This keeps upgrades recoverable and makes the final global package independent of npm's temporary cache.
 
 ## Boss CLI fork publication
 

--- a/docs/plans/2026-07-14-macos-fork-installer-design.md
+++ b/docs/plans/2026-07-14-macos-fork-installer-design.md
@@ -1,0 +1,42 @@
+# macOS and Boss CLI fork installer design
+
+## Goal
+
+Make first-time recruiting-copilot setup work on macOS without manual PATH repair, and install the maintained `Viy1204/boss-cli` fork while the upstream npm release is behind Boss's current frontend.
+
+## Dependency installer
+
+Add `skills/recruit-init/scripts/install-dependencies.sh` as the public setup seam. It must:
+
+- require Node.js 20 or newer and npm;
+- install Boss CLI from `git+https://github.com/Viy1204/boss-cli.git#main` by default;
+- allow `BOSS_CLI_SOURCE` to override that source;
+- install `@viyzhu/liepin-cli` from npm;
+- locate the npm global executable directory from `npm config get prefix`;
+- make the directory available to the running installer immediately;
+- on macOS with zsh, add one idempotent managed PATH block to `~/.zprofile` when needed;
+- use `~/.zprofile` for other zsh environments and `~/.bash_profile` or `~/.profile` for bash;
+- verify the installed executables through absolute paths so a stale parent shell cannot cause a false failure;
+- support a check-only mode for safe environment diagnosis.
+
+The managed profile block must be stable and replaceable, with clear start and end comments. Re-running the installer must not append a second block.
+
+## Workflow integration
+
+Update the recruit-init skill and README so agents run the installer instead of duplicating npm commands. Preserve the existing rule that missing platform CLIs do not block workspace creation. Explain that a new terminal inherits the repaired PATH, while the current installer already uses the resolved absolute paths.
+
+## Test seams
+
+Shell tests exercise only public behavior:
+
+1. First macOS/zsh run adds exactly one managed PATH block.
+2. A second run keeps exactly one block.
+3. An environment whose PATH already contains npm's global bin leaves the profile unchanged.
+4. The default Boss package source is the Viy1204 fork and an environment override is honored.
+5. Check-only mode does not invoke npm installation.
+
+Tests use temporary HOME directories and fake `node`, `npm`, and `uname` executables; they never change the developer's actual shell profile or global packages.
+
+## Boss CLI fork publication
+
+Validate `chore/boss-baseline-2026-07-14`, merge it into `Viy1204/boss-cli` `main`, run its TypeScript build, and push the merge. Recruiting-copilot then targets the fork's main branch so new users receive the reviewed `v10718` / `v6230` safety baseline without a private local workaround.

--- a/docs/plans/2026-07-14-macos-fork-installer-design.md
+++ b/docs/plans/2026-07-14-macos-fork-installer-design.md
@@ -39,7 +39,7 @@ Tests use temporary HOME directories and fake `node`, `npm`, and `uname` executa
 
 ## Durable fork packaging
 
-Real-machine validation found that npm 11 can install a global Git dependency as a symbolic link into npm's temporary clone directory. A later npm operation may reuse that directory and remove the `boss` executable. The installer therefore shallow-clones the selected fork ref, runs `npm ci` and the TypeScript build, creates a package archive with `npm pack`, and installs that archive globally. It only removes the previous Boss package after the new archive has built successfully. This keeps upgrades recoverable and makes the final global package independent of npm's temporary cache.
+Real-machine validation found that npm 11 can install a global Git dependency as a symbolic link into npm's temporary clone directory. A later npm operation may reuse that directory and remove the `boss` executable. The installer therefore shallow-clones the selected fork ref, runs `npm ci` and the TypeScript build, creates a package archive with `npm pack`, and installs that archive globally. It does not preemptively uninstall the previous Boss package; npm receives the completed archive as an in-place upgrade. This keeps the previous executable available through build failures and makes the final global package independent of npm's temporary cache.
 
 ## Boss CLI fork publication
 

--- a/skills/recruit-init/SKILL.md
+++ b/skills/recruit-init/SKILL.md
@@ -41,7 +41,8 @@ sh skills/recruit-init/scripts/install-dependencies.sh
    没有 → 明确告知用户"日报将输出本地 Markdown 到 runtime/reports/，功能不受影响"。**不要求用户必须装。**
 
 在 macOS 上，如果 npm 全局命令目录原本不在 `PATH`，脚本会用可重复执行的配置块
-更新 `~/.zprofile`：安装过程立即使用新路径，用户之后新开的终端也会自动生效。
+更新当前 shell 的配置文件（zsh 为 `~/.zprofile`，bash 为 `~/.bash_profile`）：
+安装过程立即使用新路径，用户之后新开的终端也会自动生效。
 
 装好 CLI 后提醒用户各跑一次 `boss login` 和 `liepin login`（扫码登录，登录态持久化）。
 如果用户此刻登录不了（比如手机不在身边），记入收尾提醒，继续建仓。

--- a/skills/recruit-init/SKILL.md
+++ b/skills/recruit-init/SKILL.md
@@ -26,7 +26,8 @@ sh skills/recruit-init/scripts/install-dependencies.sh
 `BOSS_CLI_SOURCE`。
 
 如果当前 agent 没有全局安装权限，先给同一脚本加 `--check-only`
-获取诊断结果，将需要用户执行的命令记入收尾提醒，继续建工作区，**不阻塞**。
+获取诊断结果。**无论是权限、Node/npm/git 缺失、网络、构建还是包安装失败，
+都不阻塞建工作区**：记下原始错误和待用户处理项，继续 Step 2，不要在同一失败路径上反复重试。
 
 安装后依次确认：
 
@@ -34,7 +35,7 @@ sh skills/recruit-init/scripts/install-dependencies.sh
 2. `boss help` —— Boss 直聘 CLI。没有 → 重跑安装脚本。不要直接用
    `npm install -g git+...`：部分 npm 版本会把它留成指向临时缓存的符号链接。
    本脚本会先构建并打包 fork，再安装持久化的包文件。
-3. `liepin --version` —— 猎聘 CLI。没有 → `npm install -g @viyzhu/liepin-cli`。
+3. `liepin --version` —— 猎聘 CLI。没有 → 重跑同一安装脚本，不另外维护第二条安装路径。
 4. 本机装有 Chrome 或 Edge（两个 CLI 都靠它驱动真实浏览器）。
 5. **可选**：`lark-cli --version` —— 有且已配置飞书应用凭证 → 日报出飞书云文档；
    没有 → 明确告知用户"日报将输出本地 Markdown 到 runtime/reports/，功能不受影响"。**不要求用户必须装。**

--- a/skills/recruit-init/SKILL.md
+++ b/skills/recruit-init/SKILL.md
@@ -14,14 +14,33 @@ disable-model-invocation: true
 
 ## Step 1 前置依赖检查
 
-依次检查，缺什么引导装什么，装不上也**不阻塞建仓**（记入收尾提醒）：
+先定位本 `SKILL.md` 所在的目录，然后运行它自带的安装脚本。在本模板仓库根目录中的命令是：
+
+```bash
+sh skills/recruit-init/scripts/install-dependencies.sh
+```
+
+脚本会检查 Node.js，安装 Boss / 猎聘 CLI，并在 macOS 等环境中自动修复 npm
+全局命令的 `PATH`。默认安装已适配当前 Boss 前端的维护版：
+`git+https://github.com/Viy1204/boss-cli.git#main`。如需替换来源，可在运行前设置
+`BOSS_CLI_SOURCE`。
+
+如果当前 agent 没有全局安装权限，先给同一脚本加 `--check-only`
+获取诊断结果，将需要用户执行的命令记入收尾提醒，继续建工作区，**不阻塞**。
+
+安装后依次确认：
 
 1. `node --version` —— 需要 Node ≥ 20。没有 → 引导去 https://nodejs.org 装 LTS。
-2. `boss --version` —— Boss 直聘 CLI。没有 → `npm install -g @joohw/boss-cli`。
+2. `boss help` —— Boss 直聘 CLI。没有 → 重跑安装脚本。不要直接用
+   `npm install -g git+...`：部分 npm 版本会把它留成指向临时缓存的符号链接。
+   本脚本会先构建并打包 fork，再安装持久化的包文件。
 3. `liepin --version` —— 猎聘 CLI。没有 → `npm install -g @viyzhu/liepin-cli`。
 4. 本机装有 Chrome 或 Edge（两个 CLI 都靠它驱动真实浏览器）。
 5. **可选**：`lark-cli --version` —— 有且已配置飞书应用凭证 → 日报出飞书云文档；
    没有 → 明确告知用户"日报将输出本地 Markdown 到 runtime/reports/，功能不受影响"。**不要求用户必须装。**
+
+在 macOS 上，如果 npm 全局命令目录原本不在 `PATH`，脚本会用可重复执行的配置块
+更新 `~/.zprofile`：安装过程立即使用新路径，用户之后新开的终端也会自动生效。
 
 装好 CLI 后提醒用户各跑一次 `boss login` 和 `liepin login`（扫码登录，登录态持久化）。
 如果用户此刻登录不了（比如手机不在身边），记入收尾提醒，继续建仓。

--- a/skills/recruit-init/scripts/install-dependencies.sh
+++ b/skills/recruit-init/scripts/install-dependencies.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+set -eu
+
+BOSS_CLI_SOURCE=${BOSS_CLI_SOURCE:-git+https://github.com/Viy1204/boss-cli.git#main}
+LIEPIN_CLI_SOURCE=${LIEPIN_CLI_SOURCE:-@viyzhu/liepin-cli}
+PROFILE_BLOCK_START='# >>> recruiting-copilot npm global bin >>>'
+PROFILE_BLOCK_END='# <<< recruiting-copilot npm global bin <<<'
+CHECK_ONLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: install-dependencies.sh [--check-only]
+
+Installs recruiting-copilot's Boss and Liepin CLIs. On macOS and other
+Unix-like systems, it also repairs the npm global executable PATH when needed.
+
+Environment overrides:
+  BOSS_CLI_SOURCE    npm install source for Boss CLI
+  LIEPIN_CLI_SOURCE  npm install source for Liepin CLI
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check-only) CHECK_ONLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+command -v node >/dev/null 2>&1 || die 'Node.js 20 or newer is required.'
+command -v npm >/dev/null 2>&1 || die 'npm is required.'
+
+node_major=$(node -p 'process.versions.node.split(".")[0]')
+case "$node_major" in
+  ''|*[!0-9]*) die "could not parse Node.js version: $node_major" ;;
+esac
+[ "$node_major" -ge 20 ] || die "Node.js 20 or newer is required (found $node_major)."
+
+npm_prefix=$(npm config get prefix)
+[ -n "$npm_prefix" ] || die 'npm global prefix is empty.'
+
+platform=$(uname -s 2>/dev/null || printf 'unknown')
+case "$platform" in
+  MINGW*|MSYS*|CYGWIN*) npm_bin=$npm_prefix ;;
+  *) npm_bin=$npm_prefix/bin ;;
+esac
+
+path_contains() {
+  case ":${PATH:-}:" in
+    *:"$1":*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+profile_path() {
+  case "${SHELL:-}" in
+    */zsh) printf '%s/.zprofile\n' "$HOME" ;;
+    */bash) printf '%s/.bash_profile\n' "$HOME" ;;
+    *) printf '%s/.profile\n' "$HOME" ;;
+  esac
+}
+
+write_managed_path_block() {
+  profile=$1
+  bin_dir=$2
+  mkdir -p "$(dirname "$profile")"
+  touch "$profile"
+
+  escaped_bin=$(printf '%s' "$bin_dir" | sed 's/[\\"`$]/\\&/g')
+  temp_file=$(mktemp "${TMPDIR:-/tmp}/recruiting-copilot-profile.XXXXXX")
+  awk -v start="$PROFILE_BLOCK_START" -v end="$PROFILE_BLOCK_END" '
+    $0 == start { skipping = 1; next }
+    $0 == end { skipping = 0; next }
+    !skipping { print }
+  ' "$profile" >"$temp_file"
+
+  if [ -s "$temp_file" ] && [ "$(tail -c 1 "$temp_file" 2>/dev/null || true)" != '' ]; then
+    printf '\n' >>"$temp_file"
+  fi
+  {
+    printf '%s\n' "$PROFILE_BLOCK_START"
+    printf 'export PATH="%s:$PATH"\n' "$escaped_bin"
+    printf '%s\n' "$PROFILE_BLOCK_END"
+  } >>"$temp_file"
+  mv "$temp_file" "$profile"
+}
+
+printf 'Node.js: v%s\n' "$node_major"
+printf 'npm global bin: %s\n' "$npm_bin"
+printf 'Boss CLI source: %s\n' "$BOSS_CLI_SOURCE"
+
+if ! path_contains "$npm_bin"; then
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    printf 'PATH needs update: add %s\n' "$npm_bin"
+  else
+    profile=$(profile_path)
+    write_managed_path_block "$profile" "$npm_bin"
+    PATH="$npm_bin:$PATH"
+    export PATH
+    printf 'Updated shell PATH in %s\n' "$profile"
+  fi
+fi
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  printf 'Check only: no packages were installed.\n'
+  exit 0
+fi
+
+boss_install_source=$BOSS_CLI_SOURCE
+boss_build_dir=''
+case "$BOSS_CLI_SOURCE" in
+  git+*'#'*)
+    command -v git >/dev/null 2>&1 || die 'git is required to build the Boss CLI fork.'
+    repository_and_ref=${BOSS_CLI_SOURCE#git+}
+    boss_repository=${repository_and_ref%#*}
+    boss_ref=${repository_and_ref##*#}
+    [ -n "$boss_repository" ] || die 'Boss CLI repository is empty.'
+    [ -n "$boss_ref" ] || die 'Boss CLI git ref is empty.'
+
+    boss_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/recruiting-copilot-boss.XXXXXX")
+    cleanup_boss_build() {
+      rm -rf "$boss_build_dir"
+    }
+    trap cleanup_boss_build 0 HUP INT TERM
+
+    printf 'Cloning Boss CLI fork (%s)...\n' "$boss_ref"
+    git clone --depth 1 --branch "$boss_ref" "$boss_repository" "$boss_build_dir/source"
+    printf 'Building Boss CLI fork...\n'
+    (
+      cd "$boss_build_dir/source"
+      npm ci
+      npm run build
+      npm pack --pack-destination "$boss_build_dir"
+    )
+    set -- "$boss_build_dir"/*.tgz
+    [ "$#" -eq 1 ] && [ -f "$1" ] || die 'Boss CLI build did not produce exactly one package archive.'
+    boss_install_source=$1
+    ;;
+esac
+
+printf 'Removing any existing Boss CLI package...\n'
+npm uninstall -g @joohw/boss-cli
+printf 'Installing Boss CLI from maintained fork...\n'
+npm install -g "$boss_install_source"
+printf 'Installing Liepin CLI...\n'
+npm install -g "$LIEPIN_CLI_SOURCE"
+
+boss_executable=$npm_bin/boss
+liepin_executable=$npm_bin/liepin
+[ -x "$boss_executable" ] || die "Boss CLI executable not found at $boss_executable"
+[ -x "$liepin_executable" ] || die "Liepin CLI executable not found at $liepin_executable"
+
+"$boss_executable" help >/dev/null 2>&1
+"$liepin_executable" --version >/dev/null 2>&1
+
+printf 'Boss CLI ready: %s\n' "$boss_executable"
+printf 'Liepin CLI ready: %s\n' "$liepin_executable"
+printf 'Next: run "boss login" and "liepin login" once in a new terminal.\n'

--- a/skills/recruit-init/scripts/install-dependencies.sh
+++ b/skills/recruit-init/scripts/install-dependencies.sh
@@ -145,8 +145,6 @@ case "$BOSS_CLI_SOURCE" in
     ;;
 esac
 
-printf 'Removing any existing Boss CLI package...\n'
-npm uninstall -g @joohw/boss-cli
 printf 'Installing Boss CLI from maintained fork...\n'
 npm install -g "$boss_install_source"
 printf 'Installing Liepin CLI...\n'

--- a/tests/install-dependencies.test.sh
+++ b/tests/install-dependencies.test.sh
@@ -174,19 +174,20 @@ test_boss_source_defaults_to_fork_and_can_be_overridden() {
     'overridden Boss CLI source'
 }
 
-test_existing_boss_package_is_removed_before_fork_install() {
+test_packed_fork_upgrade_does_not_preemptively_remove_existing_boss() {
   sandbox=$(mktemp -d)
   trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
   make_fake_tools "$sandbox"
 
   run_installer "$sandbox" >/dev/null
 
-  first_operation=$(grep -E '^(uninstall|install) -g ' "$sandbox/npm.log" | sed -n '1p')
-  second_operation=$(grep -E '^(uninstall|install) -g ' "$sandbox/npm.log" | sed -n '2p')
-  assert_equals 'uninstall -g @joohw/boss-cli' "$first_operation" 'existing Boss package removal order'
-  case "$second_operation" in
+  if grep '^uninstall -g @joohw/boss-cli$' "$sandbox/npm.log" >/dev/null; then
+    fail 'installer preemptively removed the existing Boss package'
+  fi
+  first_global_install=$(grep '^install -g ' "$sandbox/npm.log" | sed -n '1p')
+  case "$first_global_install" in
     'install -g '*'/joohw-boss-cli-0.6.5.tgz') ;;
-    *) fail "packed fork install order after removal (got $second_operation)" ;;
+    *) fail "packed fork upgrade source (got $first_global_install)" ;;
   esac
 }
 
@@ -205,6 +206,6 @@ test_first_macos_run_adds_profile_block
 test_second_run_keeps_one_profile_block
 test_existing_path_leaves_profile_unchanged
 test_boss_source_defaults_to_fork_and_can_be_overridden
-test_existing_boss_package_is_removed_before_fork_install
+test_packed_fork_upgrade_does_not_preemptively_remove_existing_boss
 test_check_only_does_not_install_or_edit_profile
 printf 'PASS: install-dependencies\n'

--- a/tests/install-dependencies.test.sh
+++ b/tests/install-dependencies.test.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+set -eu
+
+PROJECT_ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+INSTALLER="$PROJECT_ROOT/skills/recruit-init/scripts/install-dependencies.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_equals() {
+  expected=$1
+  actual=$2
+  message=$3
+  [ "$expected" = "$actual" ] || fail "$message (expected $expected, got $actual)"
+}
+
+make_fake_tools() {
+  sandbox=$1
+  mkdir -p "$sandbox/fake-bin" "$sandbox/npm-prefix/bin" "$sandbox/home"
+
+  cat >"$sandbox/fake-bin/node" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  --version) printf 'v24.0.0\n' ;;
+  -p) printf '24\n' ;;
+  *) exit 0 ;;
+esac
+EOF
+
+  cat >"$sandbox/fake-bin/uname" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${FAKE_UNAME:-Darwin}"
+EOF
+
+  cat >"$sandbox/fake-bin/npm" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = config ] && [ "${2:-}" = get ] && [ "${3:-}" = prefix ]; then
+  printf '%s\n' "$FAKE_NPM_PREFIX"
+  exit 0
+fi
+if [ "${1:-}" = uninstall ] && [ "${2:-}" = -g ]; then
+  printf '%s\n' "$*" >>"$FAKE_NPM_LOG"
+  exit 0
+fi
+if [ "${1:-}" = ci ]; then
+  printf '%s\n' "$*" >>"$FAKE_NPM_LOG"
+  exit 0
+fi
+if [ "${1:-}" = run ] && [ "${2:-}" = build ]; then
+  printf '%s\n' "$*" >>"$FAKE_NPM_LOG"
+  exit 0
+fi
+if [ "${1:-}" = pack ] && [ "${2:-}" = --pack-destination ]; then
+  printf '%s\n' "$*" >>"$FAKE_NPM_LOG"
+  touch "$3/joohw-boss-cli-0.6.5.tgz"
+  printf 'joohw-boss-cli-0.6.5.tgz\n'
+  exit 0
+fi
+if [ "${1:-}" = install ] && [ "${2:-}" = -g ]; then
+  printf '%s\n' "$*" >>"$FAKE_NPM_LOG"
+  case "${3:-}" in
+    *boss*|*.tgz) executable=boss ;;
+    *) executable=liepin ;;
+  esac
+  cat >"$FAKE_NPM_PREFIX/bin/$executable" <<'INNER'
+#!/bin/sh
+exit 0
+INNER
+  chmod +x "$FAKE_NPM_PREFIX/bin/$executable"
+  exit 0
+fi
+printf 'unexpected npm invocation: %s\n' "$*" >&2
+exit 2
+EOF
+
+  cat >"$sandbox/fake-bin/git" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$FAKE_GIT_LOG"
+destination=''
+for argument in "$@"; do
+  destination=$argument
+done
+mkdir -p "$destination"
+EOF
+  chmod +x "$sandbox/fake-bin/node" "$sandbox/fake-bin/npm" "$sandbox/fake-bin/uname" "$sandbox/fake-bin/git"
+}
+
+run_installer() {
+  sandbox=$1
+  shift
+  HOME="$sandbox/home" \
+  SHELL=/bin/zsh \
+  PATH="$sandbox/fake-bin:/usr/bin:/bin" \
+  FAKE_NPM_PREFIX="$sandbox/npm-prefix" \
+  FAKE_NPM_LOG="$sandbox/npm.log" \
+  FAKE_GIT_LOG="$sandbox/git.log" \
+  FAKE_UNAME=Darwin \
+    sh "$INSTALLER" "$@"
+}
+
+run_installer_with_global_bin_on_path() {
+  sandbox=$1
+  HOME="$sandbox/home" \
+  SHELL=/bin/zsh \
+  PATH="$sandbox/fake-bin:$sandbox/npm-prefix/bin:/usr/bin:/bin" \
+  FAKE_NPM_PREFIX="$sandbox/npm-prefix" \
+  FAKE_NPM_LOG="$sandbox/npm.log" \
+  FAKE_GIT_LOG="$sandbox/git.log" \
+  FAKE_UNAME=Darwin \
+    sh "$INSTALLER"
+}
+
+test_first_macos_run_adds_profile_block() {
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$sandbox"
+
+  run_installer "$sandbox"
+
+  profile="$sandbox/home/.zprofile"
+  [ -f "$profile" ] || fail 'macOS zsh setup did not create ~/.zprofile'
+  block_count=$(grep -c '^# >>> recruiting-copilot npm global bin >>>$' "$profile")
+  assert_equals 1 "$block_count" 'managed PATH block count after first run'
+  grep -F "export PATH=\"$sandbox/npm-prefix/bin:\$PATH\"" "$profile" >/dev/null ||
+    fail 'managed PATH block does not contain npm global bin'
+}
+
+test_second_run_keeps_one_profile_block() {
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$sandbox"
+
+  run_installer "$sandbox" >/dev/null
+  run_installer "$sandbox" >/dev/null
+
+  block_count=$(grep -c '^# >>> recruiting-copilot npm global bin >>>$' "$sandbox/home/.zprofile")
+  assert_equals 1 "$block_count" 'managed PATH block count after second run'
+}
+
+test_existing_path_leaves_profile_unchanged() {
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$sandbox"
+  printf 'export EXISTING_SETTING=1\n' >"$sandbox/home/.zprofile"
+
+  run_installer_with_global_bin_on_path "$sandbox" >/dev/null
+
+  actual=$(cat "$sandbox/home/.zprofile")
+  assert_equals 'export EXISTING_SETTING=1' "$actual" 'profile changed even though npm bin was already on PATH'
+}
+
+test_boss_source_defaults_to_fork_and_can_be_overridden() {
+  default_sandbox=$(mktemp -d)
+  override_sandbox=$(mktemp -d)
+  trap 'rm -rf "$default_sandbox" "$override_sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$default_sandbox"
+  make_fake_tools "$override_sandbox"
+
+  run_installer "$default_sandbox" >/dev/null
+  BOSS_CLI_SOURCE='custom-boss-package@1.0.0' \
+    run_installer "$override_sandbox" >/dev/null
+
+  default_clone=$(sed -n '1p' "$default_sandbox/git.log")
+  override_install=$(grep '^install -g ' "$override_sandbox/npm.log" | sed -n '1p')
+  case "$default_clone" in
+    'clone --depth 1 --branch main https://github.com/Viy1204/boss-cli.git '*) ;;
+    *) fail "default Boss CLI clone source (got $default_clone)" ;;
+  esac
+  assert_equals \
+    'install -g custom-boss-package@1.0.0' \
+    "$override_install" \
+    'overridden Boss CLI source'
+}
+
+test_existing_boss_package_is_removed_before_fork_install() {
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$sandbox"
+
+  run_installer "$sandbox" >/dev/null
+
+  first_operation=$(grep -E '^(uninstall|install) -g ' "$sandbox/npm.log" | sed -n '1p')
+  second_operation=$(grep -E '^(uninstall|install) -g ' "$sandbox/npm.log" | sed -n '2p')
+  assert_equals 'uninstall -g @joohw/boss-cli' "$first_operation" 'existing Boss package removal order'
+  case "$second_operation" in
+    'install -g '*'/joohw-boss-cli-0.6.5.tgz') ;;
+    *) fail "packed fork install order after removal (got $second_operation)" ;;
+  esac
+}
+
+test_check_only_does_not_install_or_edit_profile() {
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT HUP INT TERM
+  make_fake_tools "$sandbox"
+
+  run_installer "$sandbox" --check-only >/dev/null
+
+  [ ! -e "$sandbox/npm.log" ] || fail 'check-only invoked npm install'
+  [ ! -e "$sandbox/home/.zprofile" ] || fail 'check-only edited the shell profile'
+}
+
+test_first_macos_run_adds_profile_block
+test_second_run_keeps_one_profile_block
+test_existing_path_leaves_profile_unchanged
+test_boss_source_defaults_to_fork_and_can_be_overridden
+test_existing_boss_package_is_removed_before_fork_install
+test_check_only_does_not_install_or_edit_profile
+printf 'PASS: install-dependencies\n'


### PR DESCRIPTION
## What changed

- add a repeatable dependency installer for Boss and Liepin CLIs
- build and pack the maintained `Viy1204/boss-cli` fork before global installation
- repair npm global PATH configuration idempotently on macOS/zsh and bash
- document the unified setup and non-blocking fallback flow
- bump the Claude Code plugin version to 0.4.2

## Why

The upstream Boss CLI package does not yet include the current Boss `v10718` compatibility baseline. Direct global installation from a Git dependency is also unstable on npm 11 because it can leave a symbolic link into npm's temporary cache. The installer now produces a durable package archive before performing an in-place upgrade.

## Validation

- shell behavior suite covering profile writes, idempotence, source overrides, check-only mode, and upgrade behavior
- POSIX syntax checks with `sh` and `dash`
- real macOS install and repeated in-place upgrade
- installed Boss baseline verified as `v10718` / `v6230`
- standards and spec reviews passed with no remaining findings
