### PR TITLE
feat(dsh): 交互式浏览器面板——dock 形态、固定视口、反爬规避与崩溃自愈

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ skill 目录里（无需把仓库克隆成工作区）：
 `ask-viy`、`recruit-init`、`recruit-grill`、`recruit-daily`、`resume-review`、
 `interview-schedule`、`market-talent-mapping`。
 
-**附带功能——Web UI 右侧实时浏览器面板**：跑 boss-cli 命令时，DSH Web 界面
-右侧会出现「招聘浏览器」面板，实时显示 boss 浏览器的操作画面（CDP 镜像，
-约 1fps）。前提是 boss-cli 的 Chrome 在跑（任意 boss 命令会自动拉起）；没开会
-显示「浏览器未运行」。liepin-cli 暂因无固定调试端口不支持镜像（详见
-[`dsh/README.md`](dsh/README.md)）。
+**附带功能——Web UI 右侧「招聘浏览器」面板**：DSH Web 界面右侧是一只**能直接操作
+的浏览器**，鼠标、滚轮、键盘、中文输入法、粘贴都直通，等于把 BOSS 直聘开在 DSH
+里；浏览器没起时面板里点一下就能拉起（用的是 boss-cli 同一个 user-data-dir 和
+调试端口，登录态通用，之后跑 boss 命令会直连这只，不会另开一只）。默认「贴合」会
+把页面视口设成面板大小，所以文字是原生大小而不是缩小糊图。liepin-cli 暂因无固定
+调试端口不支持接管（详见 [`dsh/README.md`](dsh/README.md)）。
 
 更新 / 卸载：
 

--- a/client.js
+++ b/client.js
@@ -1,10 +1,15 @@
 /**
- * recruiting-copilot —— 浏览器端面板（右侧实时浏览器镜像）
+ * recruiting-copilot —— 浏览器端面板（可操作的远程浏览器）
  *
- * 挂进 shell.overlay（list 插槽），渲染一个右侧悬浮面板：
- * - 轮询 /plugins/recruiting-view/state.json（2s）拿各浏览器源状态与标签列表
- * - 轮询 /plugins/recruiting-view/frame.jpg（~1s）刷新最新一帧
- * - 可折叠成右缘小条、可拖宽、可选源（boss / 未来 liepin）、可选标签
+ * 挂进 shell.overlay（list 插槽），渲染一个右侧 dock 面板：
+ * - 画面走 /plugins/recruiting-view/stream.mjpg（host 侧 CDP screencast 推帧）
+ * - 鼠标 / 滚轮 / 键盘 / 中文 IME / 粘贴 全部回传 /input，等于在这里直接操作浏览器
+ * - 默认「贴合」：把页面视口 emulate 成面板尺寸，所以文字是原生大小，不是缩小糊图
+ * - 浏览器没起时面板里一键拉起（同 user-data-dir 同端口，boss 命令随后直连这只）
+ *
+ * 形态：dock 列而不是浮层 —— 面板打开时给 #root 加 margin-right 让聊天区真正
+ * 让出宽度（借鉴 dsh-better-sidebar 的 layout-push 手法），视觉上就是 DSH 的
+ * 第四列；颜色全部走 --dsw-* token。
  */
 window.__ModuleLoader__.load({
 	id: "recruiting-copilot",
@@ -13,28 +18,56 @@ window.__ModuleLoader__.load({
 		var exports = module.exports;
 		Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 		let react = require("react");
+		const h = react.createElement;
+
+		const BASE = "/plugins/recruiting-view";
+		const MIN_W = 360;
+		const WIDTH_KEY = "rcp.panel.width";
+		// 页面视口固定尺寸：BOSS 页面在这个尺寸下渲染最完整（用户确认 958×1149 刚好），
+		// 面板自身可随意拖宽，画面按比例缩放，黑边由 normalize() 兜底。
+		const FIXED_VIEWPORT = { width: 958, height: 1149 };
 
 		// ── 样式（注入一次）──────────────────────────────────────────────
 		const css = [
-			".rcp-panel{position:fixed;right:10px;top:10px;bottom:10px;width:460px;min-width:260px;max-width:70vw;z-index:60;display:flex;flex-direction:column;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2,#333);border-radius:12px;background:var(--dsw-specific-menu,#1b1b1f);box-shadow:var(--dsw-shadow-lv3,0 12px 40px rgba(0,0,0,.4));overflow:hidden}",
-			".rcp-head{display:flex;align-items:center;gap:8px;padding:7px 10px;border-bottom:1px solid var(--dsw-alias-border-l1,#26262b);flex:none}",
-			".rcp-title{font-size:12px;font-weight:600;color:var(--dsw-alias-label-primary,#eee);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}",
-			".rcp-dot{width:8px;height:8px;border-radius:50%;flex:none;background:var(--dsw-alias-text-danger,#f2574b)}",
-			".rcp-dot[data-ok='true']{background:var(--dsw-alias-text-success,#3fb68b)}",
-			".rcp-btn{flex:none;border:0;background:0 0;color:var(--dsw-alias-label-tertiary,#8a8a93);cursor:pointer;font-size:11px;line-height:18px;padding:2px 6px;border-radius:6px}",
-			".rcp-btn:hover{color:var(--dsw-alias-label-primary,#eee);background:var(--dsw-alias-fill-l2,#26262b)}",
-			".rcp-tabs{display:flex;gap:4px;padding:6px 10px;border-bottom:1px solid var(--dsw-alias-border-l1,#26262b);flex:none;overflow-x:auto}",
-			".rcp-tab{flex:none;font-size:11px;line-height:20px;padding:0 10px;border-radius:999px;border:1px solid transparent;color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;background:0 0}",
-			".rcp-tab[data-active='true']{color:var(--dsw-alias-label-primary,#eee);background:var(--dsw-alias-fill-l2,#26262b);border-color:var(--dsw-alias-border-l2,#333)}",
-			".rcp-url{flex:none;padding:4px 10px;font-size:11px;color:var(--dsw-alias-label-tertiary,#8a8a93);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:var(--dsw-font-mono,ui-monospace,monospace)}",
-			".rcp-pages{flex:none;padding:4px 10px;border-bottom:1px solid var(--dsw-alias-border-l1,#26262b);display:flex;gap:4px;overflow-x:auto}",
-			".rcp-page{flex:none;max-width:220px;font-size:11px;line-height:20px;padding:0 8px;border-radius:6px;border:1px solid var(--dsw-alias-border-l1,#26262b);color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;background:0 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}",
-			".rcp-page[data-active='true']{color:var(--dsw-alias-label-primary,#eee);border-color:var(--dsw-alias-border-l2,#333);background:var(--dsw-alias-fill-l2,#26262b)}",
-			".rcp-body{flex:1;min-height:0;position:relative;background:#fff}",
-			".rcp-body img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;display:block}",
-			".rcp-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;color:var(--dsw-alias-label-tertiary,#8a8a93);font-size:12px;background:var(--dsw-specific-bg-base,#141417)}",
-			".rcp-resizer{position:absolute;left:-3px;top:0;bottom:0;width:6px;cursor:col-resize;z-index:2}",
-			".rcp-pill{position:fixed;right:0;top:40%;z-index:60;display:flex;align-items:center;gap:6px;padding:10px 10px 10px 12px;border:1px solid var(--dsw-alias-border-l2,#333);border-right:0;border-radius:12px 0 0 12px;background:var(--dsw-specific-menu,#1b1b1f);color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;font-size:12px;box-shadow:var(--dsw-shadow-lv3,0 12px 40px rgba(0,0,0,.4))}"
+			// dock 推挤：面板打开时应用让出宽度（--rcp-dock-width 由组件写入）
+			"#root{margin-right:var(--rcp-dock-width,0px);transition:margin-right var(--ds-transition-duration-slow,.3s) var(--ds-ease-in-out,ease)}",
+			"body[data-rcp-dragging='true'] #root{transition:none}",
+			"@media (prefers-reduced-motion:reduce){#root{transition:none}}",
+			// 面板本体：dock 列 = 通栏贴边、无圆角无阴影、左边框，像 DSH 的 details 列
+			".rcp-panel{position:fixed;z-index:60;display:flex;flex-direction:column;box-sizing:border-box;border-left:1px solid var(--dsw-alias-border-l2,#333);background:var(--dsw-alias-bg-layer-1,#1b1b1f);overflow:hidden}",
+			".rcp-panel[data-mode='side']{right:0;top:0;bottom:0;min-width:360px;max-width:92vw}",
+			".rcp-panel[data-mode='max']{left:0;right:0;top:0;bottom:0;width:auto!important;border-left:none}",
+			".rcp-head{display:flex;align-items:center;gap:4px;padding:6px 8px;border-bottom:1px solid var(--dsw-alias-border-l1,#26262b);flex:none}",
+			".rcp-title{font-size:12px;font-weight:500;color:var(--dsw-alias-label-primary,#eee);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:120px;flex:none}",
+			".rcp-spacer{flex:1}",
+			".rcp-dot{width:8px;height:8px;border-radius:50%;flex:none;background:var(--dsw-alias-state-error-primary,#f2574b)}",
+			".rcp-dot[data-ok='true']{background:var(--dsw-alias-state-success-primary,#3fb68b)}",
+			".rcp-btn{flex:none;display:inline-flex;align-items:center;justify-content:center;min-width:24px;height:24px;border:1px solid transparent;background:0 0;color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;font-size:13px;line-height:1;padding:0 5px;border-radius:6px}",
+			".rcp-btn:hover{color:var(--dsw-alias-label-primary,#eee);background:var(--dsw-alias-interactive-bg-hover,rgba(255,255,255,.08))}",
+			".rcp-btn[data-on='true']{color:var(--dsw-alias-label-primary,#eee);background:var(--dsw-alias-interactive-bg-hover,rgba(255,255,255,.08));border-color:var(--dsw-alias-border-l2,#3a3a42)}",
+			".rcp-btn:disabled{opacity:.35;cursor:default;background:0 0}",
+			".rcp-addr{flex:1;min-width:60px;height:24px;font-size:11px;line-height:22px;padding:0 8px;border-radius:6px;border:1px solid var(--dsw-alias-border-l1,#26262b);background:var(--dsw-alias-bg-layer-2,#141417);color:var(--dsw-alias-label-secondary,#b8b8c0);font-family:var(--ds-font-family-code,ui-monospace,monospace);outline:0}",
+			".rcp-addr:focus{border-color:var(--dsw-alias-border-l3,#4a4a55);color:var(--dsw-alias-label-primary,#eee)}",
+			".rcp-pages{flex:none;padding:4px 8px;border-bottom:1px solid var(--dsw-alias-border-l1,#26262b);display:flex;gap:4px;overflow-x:auto;scrollbar-width:thin}",
+			".rcp-page{flex:none;display:flex;align-items:center;gap:4px;max-width:220px;font-size:11px;line-height:20px;padding:0 4px 0 8px;border-radius:6px;border:1px solid var(--dsw-alias-border-l1,#26262b);color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;background:0 0;white-space:nowrap}",
+			".rcp-page span{overflow:hidden;text-overflow:ellipsis;max-width:170px}",
+			".rcp-page[data-active='true']{color:var(--dsw-alias-label-primary,#eee);border-color:var(--dsw-alias-border-l2,#3a3a42);background:var(--dsw-alias-bg-module-platform,#26262b)}",
+			".rcp-x{opacity:.45;padding:0 3px;border-radius:4px;cursor:pointer}",
+			".rcp-x:hover{opacity:1;background:var(--dsw-alias-interactive-bg-hover,rgba(255,255,255,.08))}",
+			".rcp-body{flex:1;min-height:0;position:relative;background:var(--dsw-alias-bg-layer-3,#0b0b0d);overflow:hidden;outline:0}",
+			".rcp-body img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;display:block;user-select:none;-webkit-user-drag:none}",
+			".rcp-body[data-live='true']{cursor:default}",
+			".rcp-focus{position:absolute;inset:0;pointer-events:none;border:2px solid transparent;border-radius:2px;transition:border-color .15s}",
+			".rcp-body[data-focus='true'] .rcp-focus{border-color:var(--dsw-alias-state-success-primary,#3fb68b)}",
+			".rcp-ime{position:absolute;width:2px;height:16px;opacity:0;border:0;padding:0;margin:0;background:0 0;color:transparent;resize:none;outline:0;pointer-events:none;overflow:hidden}",
+			".rcp-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;color:var(--dsw-alias-label-tertiary,#8a8a93);font-size:12px;text-align:center;padding:20px}",
+			".rcp-empty-icon{font-size:30px;line-height:1}",
+			".rcp-empty-title{font-size:13px;font-weight:500;color:var(--dsw-alias-label-primary,#eee)}",
+			".rcp-cta{border:1px solid transparent;background:var(--dsw-alias-button-primary-fill,var(--dsw-alias-brand-primary,#4176e6));color:var(--dsw-alias-label-primary-foreground,#fff);border-radius:8px;padding:6px 14px;font-size:12px;cursor:pointer}",
+			".rcp-cta:hover{background:var(--dsw-alias-button-primary-hover,#2f4c8f)}",
+			".rcp-foot{flex:none;display:flex;align-items:center;gap:8px;padding:3px 8px;border-top:1px solid var(--dsw-alias-border-l1,#26262b);font-size:10px;color:var(--dsw-alias-label-tertiary,#8a8a93);font-family:var(--ds-font-family-code,ui-monospace,monospace)}",
+			".rcp-resizer{position:absolute;left:-4px;top:0;bottom:0;width:8px;cursor:col-resize;z-index:2}",
+			".rcp-pill{position:fixed;right:0;top:40%;z-index:60;display:flex;align-items:center;gap:6px;padding:10px 10px 10px 12px;border:1px solid var(--dsw-alias-border-l2,#333);border-right:0;border-radius:12px 0 0 12px;background:var(--dsw-alias-bg-layer-1,#1b1b1f);color:var(--dsw-alias-label-secondary,#b8b8c0);cursor:pointer;font-size:12px;box-shadow:var(--dsw-shadow-lv2,0 4px 12px rgba(0,0,0,.2))}"
 		].join("\n");
 		const tagId = "recruiting-copilot/BrowserPanel.css";
 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
@@ -45,122 +78,453 @@ window.__ModuleLoader__.load({
 			document.head.appendChild(tag);
 		}
 
+		// ── 输入事件队列：单飞行 POST，按 TCP 顺序到达 host ────────────────
+		function makeInputQueue(source) {
+			let queue = [];
+			let flying = false;
+			const flush = () => {
+				if (flying || queue.length === 0) return;
+				const events = queue;
+				queue = [];
+				flying = true;
+				fetch(`${BASE}/input?source=${encodeURIComponent(source())}`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ events })
+				})
+					.catch(() => {})
+					.finally(() => {
+						flying = false;
+						if (queue.length > 0) flush();
+					});
+			};
+			return {
+				push(ev) {
+					// 连续 mouseMoved 合并成最后一个，避免拖动时堆积。
+					const last = queue[queue.length - 1];
+					if (ev.kind === "mouse" && ev.type === "mouseMoved" && last && last.kind === "mouse" && last.type === "mouseMoved") {
+						queue[queue.length - 1] = ev;
+					} else {
+						queue.push(ev);
+					}
+					flush();
+				}
+			};
+		}
+
+		/** DOM 修饰键位 → CDP modifiers 位掩码（alt1 ctrl2 meta4 shift8）。 */
+		function modifiersOf(e) {
+			return (e.altKey ? 1 : 0) | (e.ctrlKey ? 2 : 0) | (e.metaKey ? 4 : 0) | (e.shiftKey ? 8 : 0);
+		}
+
+		/** 事件坐标 → 图像内容区归一化坐标（兼容 object-fit: contain 的黑边）。 */
+		function normalize(e, box, img) {
+			const rect = box.getBoundingClientRect();
+			const natW = img?.naturalWidth || 0;
+			const natH = img?.naturalHeight || 0;
+			let dispW = rect.width;
+			let dispH = rect.height;
+			let offX = 0;
+			let offY = 0;
+			if (natW > 0 && natH > 0) {
+				const scale = Math.min(rect.width / natW, rect.height / natH);
+				dispW = natW * scale;
+				dispH = natH * scale;
+				offX = (rect.width - dispW) / 2;
+				offY = (rect.height - dispH) / 2;
+			}
+			return {
+				nx: dispW > 0 ? (e.clientX - rect.left - offX) / dispW : 0,
+				ny: dispH > 0 ? (e.clientY - rect.top - offY) / dispH : 0,
+				dispW,
+				dispH
+			};
+		}
+
+		const BUTTONS = ["left", "middle", "right", "back", "forward"];
+
+		function readStoredWidth() {
+			try {
+				const saved = Number.parseInt(localStorage.getItem(WIDTH_KEY), 10);
+				if (Number.isFinite(saved) && saved >= MIN_W) return Math.min(saved, Math.floor(window.innerWidth * 0.92));
+			} catch { /* 无 localStorage 时走默认 */ }
+			return Math.min(Math.round(window.innerWidth * 0.42), 720);
+		}
+
 		// ── 面板组件 ────────────────────────────────────────────────────
 		function BrowserPanel() {
 			const [state, setState] = react.useState(null);
 			const [activeSource, setActiveSource] = react.useState("boss");
-			const [frameSrc, setFrameSrc] = react.useState(null);
 			const [collapsed, setCollapsed] = react.useState(false);
-			const [width, setWidth] = react.useState(460);
-			const dragging = react.useRef(false);
+			const [mode, setMode] = react.useState("side");
+			const [width, setWidth] = react.useState(readStoredWidth);
+			const [fit, setFit] = react.useState(true);
+			const [interactive, setInteractive] = react.useState(true);
+			const [focused, setFocused] = react.useState(false);
+			const [addr, setAddr] = react.useState("");
+			const [addrDirty, setAddrDirty] = react.useState(false);
+			const [streamKey, setStreamKey] = react.useState(0);
 
+			const bodyRef = react.useRef(null);
+			const imgRef = react.useRef(null);
+			const imeRef = react.useRef(null);
+			const dragging = react.useRef(false);
+			const sourceRef = react.useRef(activeSource);
+			sourceRef.current = activeSource;
+			const queueRef = react.useRef(null);
+			if (queueRef.current === null) queueRef.current = makeInputQueue(() => sourceRef.current);
+
+			const control = react.useCallback((action, payload) => {
+				return fetch(`${BASE}/control?source=${encodeURIComponent(sourceRef.current)}`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify(Object.assign({ action }, payload ?? {}))
+				})
+					.then((r) => r.json())
+					.catch(() => ({ ok: false }));
+			}, []);
+
+			// 状态轮询
 			react.useEffect(() => {
+				let alive = true;
 				const loadState = () => {
-					fetch("/plugins/recruiting-view/state.json", { cache: "no-store" })
+					fetch(`${BASE}/state.json`, { cache: "no-store" })
 						.then((r) => (r.ok ? r.json() : null))
 						.then((data) => {
-							if (data) setState(data);
+							if (alive && data) setState(data);
 						})
 						.catch(() => {});
 				};
 				loadState();
-				const timer = setInterval(loadState, 2000);
-				return () => clearInterval(timer);
-			}, []);
-
-			// 帧轮询：以当前源 + 时间戳作缓存破坏
-			react.useEffect(() => {
-				const loadFrame = () => setFrameSrc(`/plugins/recruiting-view/frame.jpg?source=${encodeURIComponent(activeSource)}&t=${Date.now()}`);
-				loadFrame();
-				const timer = setInterval(loadFrame, 1000);
-				return () => clearInterval(timer);
-			}, [activeSource]);
-
-			react.useEffect(() => {
-				const onMove = (e) => {
-					if (!dragging.current) return;
-					const next = Math.min(Math.max(window.innerWidth - e.clientX - 10, 260), Math.floor(window.innerWidth * 0.7));
-					setWidth(next);
-				};
-				const onUp = () => { dragging.current = false; };
-				window.addEventListener("mousemove", onMove);
-				window.addEventListener("mouseup", onUp);
+				const timer = setInterval(loadState, 1500);
 				return () => {
-					window.removeEventListener("mousemove", onMove);
-					window.removeEventListener("mouseup", onUp);
+					alive = false;
+					clearInterval(timer);
 				};
 			}, []);
 
-			if (collapsed) {
-				return react.createElement("div", {
-					className: "rcp-pill",
-					onClick: () => setCollapsed(false),
-					title: "展开招聘浏览器"
-				}, "▶ 招聘浏览器");
-			}
+			// dock 推挤：dock 态把宽度写给 #root 的 margin-right；折叠/整屏时让出 0。
+			react.useEffect(() => {
+				const dock = mode === "side" && !collapsed ? Math.round(width) : 0;
+				document.documentElement.style.setProperty("--rcp-dock-width", `${dock}px`);
+				return () => {
+					document.documentElement.style.removeProperty("--rcp-dock-width");
+				};
+			}, [mode, collapsed, width]);
+
+			// 记住面板宽度（刷新后恢复）
+			react.useEffect(() => {
+				try {
+					localStorage.setItem(WIDTH_KEY, String(width));
+				} catch { /* 忽略 */ }
+			}, [width]);
+
+			// 盯梢：面板未折叠时告诉 host「浏览器崩了自动重新拉起」
+			react.useEffect(() => {
+				control("watch", { on: !collapsed });
+				return () => {
+					control("watch", { on: false });
+				};
+			}, [collapsed, control]);
 
 			const sources = (state?.sources ?? []).filter((s) => s != null);
 			const active = sources.find((s) => s.name === activeSource) ?? sources[0];
 			const sourceName = active?.name ?? "boss";
 			const pages = active?.pages ?? [];
 			const connected = active?.connected === true;
-			const frameTs = active?.seq ?? 0;
+			const launching = active?.launching === true;
+			const viewport = active?.viewport ?? { width: 0, height: 0 };
 
-			const onPagePick = (pageId) => {
-				fetch(`/plugins/recruiting-view/set-target?source=${encodeURIComponent(sourceName)}&pageId=${encodeURIComponent(pageId)}`, { cache: "no-store" }).catch(() => {});
-			};
+			// 地址栏跟随真实 URL（用户正在编辑时不覆盖）
+			react.useEffect(() => {
+				if (!addrDirty) setAddr(active?.targetUrl ?? "");
+			}, [active?.targetUrl, addrDirty]);
 
-			return react.createElement("div", {
-				className: "rcp-panel",
-				style: { width }
-			},
-				react.createElement("div", { className: "rcp-resizer", onMouseDown: () => { dragging.current = true; } }),
-				react.createElement("div", { className: "rcp-head" },
-					react.createElement("span", { className: "rcp-dot", "data-ok": String(connected) }),
-					react.createElement("span", { className: "rcp-title" }, "招聘浏览器 · " + sourceName + (connected ? "" : "（未连接）")),
-					react.createElement("button", { className: "rcp-btn", onClick: () => setCollapsed(true), title: "折叠" }, "—")
+			// 贴合：页面视口固定为 FIXED_VIEWPORT（与面板大小解耦——面板拖宽只影响
+			// 显示缩放，不影响页面渲染尺寸，保证 BOSS 页面永远截得全）。
+			react.useEffect(() => {
+				if (!fit) {
+					control("unfit");
+					return undefined;
+				}
+				control("fit", {
+					width: FIXED_VIEWPORT.width,
+					height: FIXED_VIEWPORT.height,
+					deviceScaleFactor: Math.min(Math.max(window.devicePixelRatio || 1, 1), 2)
+				});
+			}, [fit, collapsed, mode, control]);
+
+			// 断线后重连：重挂 MJPEG（img 的 src 不变时不会自动重连）
+			react.useEffect(() => {
+				if (connected) setStreamKey((k) => k + 1);
+			}, [connected, sourceName]);
+
+			// 面板拖宽（dock 贴边：宽度 = 视口右缘到鼠标）
+			react.useEffect(() => {
+				const onMove = (e) => {
+					if (!dragging.current) return;
+					setWidth(Math.min(Math.max(window.innerWidth - e.clientX, MIN_W), Math.floor(window.innerWidth * 0.92)));
+				};
+				const onUp = () => {
+					dragging.current = false;
+					document.body.removeAttribute("data-rcp-dragging");
+				};
+				window.addEventListener("mousemove", onMove);
+				window.addEventListener("mouseup", onUp);
+				return () => {
+					window.removeEventListener("mousemove", onMove);
+					window.removeEventListener("mouseup", onUp);
+					document.body.removeAttribute("data-rcp-dragging");
+				};
+			}, []);
+
+			// ── 输入转发 ─────────────────────────────────────────────────
+			const sendMouse = react.useCallback((type, e, extra) => {
+				const box = bodyRef.current;
+				if (!box) return;
+				const { nx, ny, dispW, dispH } = normalize(e, box, imgRef.current);
+				const ev = {
+					kind: "mouse",
+					type,
+					nx,
+					ny,
+					button: type === "mouseMoved" && e.buttons === 0 ? "none" : BUTTONS[e.button] ?? "left",
+					buttons: e.buttons ?? 0,
+					clickCount: type === "mousePressed" || type === "mouseReleased" ? e.detail || 1 : 0,
+					modifiers: modifiersOf(e)
+				};
+				if (type === "mouseWheel") {
+					ev.button = "none";
+					ev.ndx = dispW > 0 ? extra.deltaX / dispW : 0;
+					ev.ndy = dispH > 0 ? extra.deltaY / dispH : 0;
+				}
+				queueRef.current.push(ev);
+			}, []);
+
+			const focusIme = react.useCallback((e) => {
+				const ime = imeRef.current;
+				const box = bodyRef.current;
+				if (!ime || !box) return;
+				if (e) {
+					const rect = box.getBoundingClientRect();
+					ime.style.left = `${Math.round(e.clientX - rect.left)}px`;
+					ime.style.top = `${Math.round(e.clientY - rect.top)}px`;
+				}
+				ime.focus({ preventScroll: true });
+			}, []);
+
+			const onMouseDown = react.useCallback((e) => {
+				if (!interactive || !connected) return;
+				e.preventDefault();
+				focusIme(e);
+				sendMouse("mousePressed", e);
+			}, [interactive, connected, focusIme, sendMouse]);
+
+			const onMouseMove = react.useCallback((e) => {
+				if (!interactive || !connected) return;
+				sendMouse("mouseMoved", e);
+			}, [interactive, connected, sendMouse]);
+
+			const onMouseUp = react.useCallback((e) => {
+				if (!interactive || !connected) return;
+				e.preventDefault();
+				sendMouse("mouseReleased", e);
+			}, [interactive, connected, sendMouse]);
+
+			// wheel 要用非 passive 监听才能 preventDefault，React 的 onWheel 是 passive
+			react.useEffect(() => {
+				const box = bodyRef.current;
+				if (!box) return undefined;
+				const onWheel = (e) => {
+					if (!interactive || !connected) return;
+					e.preventDefault();
+					sendMouse("mouseWheel", e, { deltaX: e.deltaX, deltaY: e.deltaY });
+				};
+				box.addEventListener("wheel", onWheel, { passive: false });
+				return () => box.removeEventListener("wheel", onWheel);
+			}, [interactive, connected, sendMouse]);
+
+			const onKey = react.useCallback((e, type) => {
+				if (!interactive || !connected) return;
+				if (e.isComposing || e.keyCode === 229) return; // 交给 IME，compositionend 再发
+				e.preventDefault();
+				e.stopPropagation();
+				const printable = e.key.length === 1 && !e.ctrlKey && !e.metaKey;
+				queueRef.current.push({
+					kind: "key",
+					type: type === "down" ? (printable ? "keyDown" : "rawKeyDown") : "keyUp",
+					key: e.key,
+					code: e.code,
+					keyCode: e.keyCode || e.which || 0,
+					text: type === "down" && printable ? e.key : undefined,
+					autoRepeat: e.repeat === true,
+					location: e.location ?? 0,
+					modifiers: modifiersOf(e)
+				});
+			}, [interactive, connected]);
+
+			const onCompositionEnd = react.useCallback((e) => {
+				const text = e.data ?? "";
+				if (text.length > 0) queueRef.current.push({ kind: "text", text });
+				if (imeRef.current) imeRef.current.value = "";
+			}, []);
+
+			const onPaste = react.useCallback((e) => {
+				if (!interactive || !connected) return;
+				const text = e.clipboardData?.getData("text") ?? "";
+				e.preventDefault();
+				if (text.length > 0) queueRef.current.push({ kind: "text", text });
+			}, [interactive, connected]);
+
+			const submitAddr = react.useCallback((e) => {
+				e.preventDefault();
+				setAddrDirty(false);
+				control("navigate", { url: addr });
+			}, [addr, control]);
+
+			if (collapsed) {
+				return h("div", {
+					className: "rcp-pill",
+					onClick: () => setCollapsed(false),
+					title: "展开招聘浏览器"
+				}, "▶ 招聘浏览器");
+			}
+
+			const btn = (label, title, onClick, extra) =>
+				h("button", Object.assign({ className: "rcp-btn", title, onClick, key: title }, extra ?? {}), label);
+
+			const head = h("div", { className: "rcp-head" },
+				h("span", { className: "rcp-dot", "data-ok": String(connected) }),
+				h("span", { className: "rcp-title", title: active?.targetTitle ?? sourceName }, active?.targetTitle || sourceName),
+				btn("←", "后退", () => control("back"), { disabled: !connected }),
+				btn("→", "前进", () => control("forward"), { disabled: !connected }),
+				btn("⟳", "刷新", () => control("reload"), { disabled: !connected }),
+				h("form", { className: "rcp-spacer", style: { display: "flex" }, onSubmit: submitAddr },
+					h("input", {
+						className: "rcp-addr",
+						value: addr,
+						placeholder: connected ? "输入网址回车跳转" : "浏览器未连接",
+						spellCheck: false,
+						disabled: !connected,
+						onChange: (e) => { setAddr(e.target.value); setAddrDirty(true); },
+						onBlur: () => setAddrDirty(false)
+					})
 				),
-				react.createElement("div", { className: "rcp-tabs" },
-					sources.length > 0
-						? sources.map((s) => react.createElement("button", {
-							key: s.name,
-							className: "rcp-tab",
-							"data-active": String(s.name === sourceName),
-							onClick: () => setActiveSource(s.name)
-						}, s.name + (s.connected === true ? "" : " ⚠")))
-						: react.createElement("span", { className: "rcp-tab", "data-active": "true" }, "boss")
-				),
-				react.createElement("div", { className: "rcp-url" }, active?.targetUrl ?? "等待浏览器…"),
-				pages.length > 1
-					? react.createElement("div", { className: "rcp-pages" },
-						pages.map((p) => react.createElement("button", {
-							key: p.id,
-							className: "rcp-page",
-							"data-active": String(p.id === active?.targetId),
-							onClick: () => onPagePick(p.id),
-							title: p.url
-						}, (p.title || p.url || "untitled").slice(0, 40)))
-					)
+				btn("＋", "新标签页", () => control("new-tab"), { disabled: !connected }),
+				btn(interactive ? "🖱" : "🔒", interactive ? "可操作（点画面直接操作浏览器）" : "只读（点击不再传给浏览器）", () => setInteractive((v) => !v), { "data-on": String(interactive) }),
+				btn("贴合", "贴合：页面视口固定 958×1149（截得全）；关掉则显示浏览器真实窗口画面", () => setFit((v) => !v), { "data-on": String(fit) }),
+				btn(mode === "max" ? "⇲" : "⇱", mode === "max" ? "还原为右侧面板" : "放大到整屏", () => setMode((m) => (m === "max" ? "side" : "max"))),
+				btn("—", "折叠", () => setCollapsed(true))
+			);
+
+			const tabs = h("div", { className: "rcp-pages" },
+				sources.length > 1
+					? sources.map((s) => h("button", {
+						key: `src-${s.name}`,
+						className: "rcp-page",
+						"data-active": String(s.name === sourceName),
+						onClick: () => setActiveSource(s.name)
+					}, h("span", null, s.name)))
 					: null,
-				react.createElement("div", { className: "rcp-body" },
-					connected && frameSrc
-						? react.createElement("img", { key: frameTs, src: frameSrc, alt: "browser frame" })
-						: react.createElement("div", { className: "rcp-empty" },
-							react.createElement("span", null, connected ? "正在连接浏览器…" : "浏览器未运行"),
-							react.createElement("span", null, "运行 boss/liepin 命令后这里会实时显示操作界面")
-						)
-				)
+				pages.map((p) => h("div", {
+					key: p.id,
+					className: "rcp-page",
+					"data-active": String(p.id === active?.targetId),
+					title: p.url,
+					onClick: () => control("set-target", { pageId: p.id })
+				},
+					h("span", null, p.title || p.url || "untitled"),
+					h("span", {
+						className: "rcp-x",
+						title: "关闭标签",
+						onClick: (e) => { e.stopPropagation(); control("close-tab", { pageId: p.id }); }
+					}, "×")
+				))
+			);
+
+			const body = h("div", {
+				className: "rcp-body",
+				ref: bodyRef,
+				"data-live": String(connected && interactive),
+				"data-focus": String(focused && interactive),
+				onMouseDown,
+				onMouseMove,
+				onMouseUp,
+				onContextMenu: (e) => e.preventDefault()
+			},
+				connected
+					? h("img", {
+						key: `${sourceName}-${streamKey}`,
+						ref: imgRef,
+						src: `${BASE}/stream.mjpg?source=${encodeURIComponent(sourceName)}&k=${streamKey}`,
+						alt: "browser",
+						draggable: false
+					})
+					: h("div", { className: "rcp-empty" },
+						h("span", { className: "rcp-empty-icon" }, "🌐"),
+						h("span", { className: "rcp-empty-title" }, launching ? "正在启动浏览器…" : "浏览器未运行"),
+						h("button", {
+							className: "rcp-cta",
+							onClick: () => control("launch").then(() => setTimeout(() => setStreamKey((k) => k + 1), 1500))
+						}, launching ? "启动中…" : "在这里启动浏览器"),
+						h("span", { style: { opacity: .7 } }, "用 boss-cli 同一用户数据目录和调试端口，登录态通用"),
+						active?.error ? h("span", { style: { color: "var(--dsw-alias-state-error-primary,#f2574b)" } }, String(active.error)) : null
+					),
+				h("textarea", {
+					ref: imeRef,
+					className: "rcp-ime",
+					autoComplete: "off",
+					spellCheck: false,
+					onKeyDown: (e) => onKey(e, "down"),
+					onKeyUp: (e) => onKey(e, "up"),
+					onCompositionEnd,
+					onPaste,
+					onFocus: () => setFocused(true),
+					onBlur: () => setFocused(false),
+					onInput: (e) => { if (!e.nativeEvent.isComposing) e.target.value = ""; }
+				}),
+				h("div", { className: "rcp-focus" })
+			);
+
+			const foot = h("div", { className: "rcp-foot" },
+				h("span", null, connected ? `${viewport.width}×${viewport.height}` : "—"),
+				h("span", null, active?.frameMode === "screencast" ? "推流" : active?.frameMode === "poll" ? "轮询" : "空闲"),
+				h("span", { className: "rcp-spacer" }),
+				h("span", { className: "rcp-x", title: "把真实浏览器窗口唤到前台", onClick: () => control("activate") }, "唤起窗口")
+			);
+
+			return h("div", {
+				className: "rcp-panel",
+				"data-mode": mode,
+				style: mode === "side" ? { width } : undefined
+			},
+				mode === "side"
+					? h("div", {
+						className: "rcp-resizer",
+						onMouseDown: () => {
+							dragging.current = true;
+							document.body.setAttribute("data-rcp-dragging", "true");
+						}
+					})
+					: null,
+				head,
+				pages.length > 0 || sources.length > 1 ? tabs : null,
+				body,
+				foot
 			);
 		}
 
 		/** 客户端插件主体：注册右侧面板到 shell.overlay。 */
 		function apply(ctx) {
-			ctx.effect(() => ctx.slots.register({
-				name: "shell.overlay",
-				id: "recruiting-view",
-				priority: 0,
-				label: "招聘浏览器"
-			}, BrowserPanel), "recruiting-copilot: browser panel");
+			// slots 是 cordis 服务，必须经 inject 才能访问；放子纤维里等服务就绪再注册。
+			ctx.inject(["slots"], (ctx) => {
+				ctx.effect(() => ctx.slots.register({
+					name: "shell.overlay",
+					id: "recruiting-view",
+					priority: 0,
+					label: "招聘浏览器"
+				}, BrowserPanel), "recruiting-copilot: browser panel");
+			});
 		}
 
 		exports.apply = apply;

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -9,11 +9,14 @@
 - `cordis.patch.yml` 是 profile 的 patch 层：启用宿主 `skill-filesystem` 行，
   把本包 `skills/` 目录挂为全局自定义 skill 根（rank 300，custom 源），并挂载
   本包自身（host 插件 + 客户端面板）。
-- `lib/index.js` 是 host 插件：通过 CDP 把 boss-cli 的浏览器实时镜像成 JPEG 帧，
-  暴露 `/plugins/recruiting-view/*` 路由（无第三方依赖，只用 Node 内置
-  fetch/WebSocket）。
+- `lib/index.js` 是 host 插件：通过 CDP 把 boss-cli 的浏览器变成一只可远程操作的
+  浏览器——`Page.startScreencast` 推帧 + `Input.*` 收事件，暴露
+  `/plugins/recruiting-view/*` 路由（无第三方依赖，只用 Node 内置
+  fetch/WebSocket/child_process）。
 - `client.js` 是浏览器端模块：注册进 `shell.overlay` 插槽，在 Web UI 右侧渲染
-  实时浏览器面板（轮询帧流、可折叠/调宽、可选源与标签）。
+  可操作的浏览器面板，**dock 列形态**（打开时给 `#root` 加 `margin-right` 让出
+  宽度，聊天不被遮挡，视觉与 DSH 内置列一致）：MJPEG 画面、鼠标/滚轮/键盘/IME
+  回传、地址栏与标签页、贴合视口、整屏/折叠/调宽（宽度记忆到 localStorage）。
 
 ## 安装 / 更新 / 卸载
 
@@ -32,21 +35,40 @@ dsh plugin --profile web remove recruiting-copilot
 
 1. `skills/` 下 7 个 skill（ask-viy、recruit-init、recruit-grill、recruit-daily、
    resume-review、interview-schedule、market-talent-mapping）在任意工作区可用。
-2. Web UI 右侧出现「招聘浏览器」面板：运行 boss-cli 命令时实时显示其操作界面。
+2. Web UI 右侧出现「招聘浏览器」面板：一只可以直接用的浏览器。
 
 ## 招聘浏览器面板
 
 - **原理**：boss-cli 固定占用 CDP 调试端口 `53470`（见 boss-cli 的
-  `REMOTE_DEBUGGING_PORT`），浏览器跨命令常驻；本插件的 host 半区并行挂到同一
-  只浏览器上，每秒抓一帧 JPEG，经 `/plugins/recruiting-view/frame.jpg` 供面板轮询。
-- **依赖**：boss-cli 的 Chrome 在跑（或由任意 boss 命令拉起）。浏览器没开时
-  面板显示「浏览器未运行」，不报错。
+  `REMOTE_DEBUGGING_PORT`），浏览器跨命令常驻；host 半区并行挂到同一只浏览器上，
+  `Page.startScreencast` 推 JPEG 帧（有变化才推），经
+  `/plugins/recruiting-view/stream.mjpg` 以 MJPEG 长连接喂给面板的 `<img>`；
+  面板把鼠标/滚轮/键盘/IME 事件回传 `/input`，host 转成 `Input.*` 派发。
+- **看得清的关键是「贴合」**：host 用 `Emulation.setDeviceMetricsOverride` 把页面
+  视口固定为 **958×1149**（用户确认 BOSS 页面在这个尺寸下渲染最完整），与面板大小
+  解耦——面板随意拖宽只影响显示缩放，不影响页面渲染尺寸。关掉贴合则显示浏览器真实
+  窗口画面（会被缩小）。
+  取消贴合必须**先用 0 宽高把覆盖接管到当前会话、再 `clearDeviceMetricsOverride`**，
+  只发 clear 清不掉别的（已断开）会话留下的覆盖——插件 dispose 时也走这条路径，
+  免得关掉 DSH 后真实浏览器卡在面板尺寸。
+- **浏览器没起时**：面板里点「在这里启动浏览器」，host 用与 boss-cli 相同的
+  user-data-dir（`~/.boss-cli/.cache/browser-data`）和调试端口拉起 Chrome，登录态
+  通用；之后跑 boss 命令会 `probe` 到这只已存在的实例直接复用，不会另开一只。
+- **窗口被遮挡/最小化**：screencast 会静默，看门狗自动回落到
+  `Page.captureScreenshot` 轮询（面板底部状态栏会显示「轮询」）。
+- **坐标**：面板传归一化坐标（0..1），host 乘当前视口尺寸，因此面板缩放/letterbox
+  都不影响命中；实测面板点 (x,y) 与页面 (x,y) 逐像素对齐。
+- **键盘**：面板里有个透明 textarea 承接按键，点画面即聚焦；中文走
+  `compositionend` → `Input.insertText`，粘贴同理。功能键发 `rawKeyDown`，
+  可打印字符发带 `text` 的 `keyDown`。
 - **liepin**：liepin-cli 目前用 `puppeteer.launch()` 且无固定调试端口，暂不能
-  镜像；等 liepin-cli 支持固定端口后，在 profile 的 `cordis.patch.yml` 里给
+  接管；等 liepin-cli 支持固定端口后，在 profile 的 `cordis.patch.yml` 里给
   `recruiting-copilot` 的 `config.sources` 加一项
   `{ name: "liepin", port: <端口>, match: "liepin\\.com" }` 即可，无需改本仓库。
-- **路由**：`state.json`（状态+标签列表）、`frame.jpg`（最新帧）、
-  `set-target`（切换抓取标签）。
+- **路由**：`state.json`（状态+标签+视口）、`stream.mjpg`（实时画面）、
+  `frame.jpg`（单帧兜底）、`input`（POST 事件批）、`control`（POST：launch /
+  navigate / reload / back / forward / new-tab / close-tab / set-target /
+  activate / fit / unfit）。
 
 ## 原理速览
 
@@ -61,19 +83,26 @@ dsh plugin --profile web remove recruiting-copilot
 - host 插件不声明必选 `inject`（headless 无 webServer 也能挂载），路由注册放在
   `ctx.inject({ webServer: {} }, ...)` 子纤维里，等服务可用再注册。
 - 客户端模块契约：`window.__ModuleLoader__.load({ id, factory })`，`factory`
-  里 `require("react")` 等共享模块，`apply(ctx)` 里 `ctx.slots.register` 进
-  `shell.overlay`（list 插槽，需 `id`）。
+  里 `require("react")` 等共享模块，`apply(ctx)` 里注册进 `shell.overlay`
+  （list 插槽，需 `id`）。**`slots` 是 cordis 服务，必须 `ctx.inject(["slots"], …)`
+  才能访问**——直接读 `ctx.slots` 会以
+  `cannot get property "slots" without inject` 整个模块加载失败。
 
 ## 本地验证（改动后必做）
 
 ```bash
 cd 本仓库
-npm pack            # 产物应包含 dsh/、skills/、lib/、client.js
+node --test "tests/*.test.mjs"  # 单测：坐标换算、输入参数、贴合/还原调用序列
 node --check client.js && node --check lib/index.js
+npm pack                         # 产物应包含 dsh/、skills/、lib/、client.js
+
+# 真机联调（不起 DSH，直接把 host 插件挂裸 http 上）：
+node tests/harness-live.mjs 3081
+curl http://127.0.0.1:3081/plugins/recruiting-view/state.json
+node tests/input-e2e.mjs 3081    # 端到端验证鼠标/滚轮/键盘真的进了页面
+
 # 隔离验证（不碰在跑的 GUI）：
 DSH_HOME=$(mktemp -d) dsh plugin --profile web add link:$(pwd)
-DSH_HOME=同上 dsh --profile web --port 3081   # 起隔离实例
-curl http://127.0.0.1:3081/plugins/recruiting-copilot/client.js
-curl http://127.0.0.1:3081/plugins/recruiting-view/state.json
-curl -o f.jpg http://127.0.0.1:3081/plugins/recruiting-view/frame.jpg
+DSH_HOME=同上 dsh --profile web --port 3082   # 起隔离实例
+curl http://127.0.0.1:3082/plugins/recruiting-copilot/client.js
 ```

--- a/dsh/panel-ux-redesign.md
+++ b/dsh/panel-ux-redesign.md
@@ -1,0 +1,150 @@
+# 招聘浏览器面板 —— UX 改造计划（2026-08-14）
+
+> 现状：面板功能全部可用（鼠标/滚轮/键盘/IME/贴合/多标签），但「形态」不贴
+> DeepSeek Harness Web UI：一只常驻工作区被做成了悬浮弹窗卡片。本文档给三档
+> 改造方向 + 社区可抄的方案，改动全部落在 `client.js`（面板）与 `lib/index.js`
+> （传输层），不碰 DSH 本体。
+
+## 一、为什么「不够适配」（诊断）
+
+1. **挂载语义**：面板挂在 `shell.overlay`（list 插槽，官方注释定位是"浮在整个应用
+   之上的表面"——审批/提问等瞬态层），但招聘浏览器是**常驻工作区**。DSH 常驻右栏
+   是 `details` 列（`dsh-client-ui-layout` 的 AppFrame：`sidebar | center | details`
+   三列网格，原生拖拽把手、300–520px、可关闭），它被会话的 DetailsPanel（轨迹/工具
+   详情）占用，是 single 插槽，直接抢会顶掉会话详情。
+2. **视觉语言**：`position:fixed` + 10px 边距 + `border-radius:12px` +
+   `shadow-lv3` 大阴影 + 自定义 pill = 典型"第三方弹窗"。DSH 的列是
+   `border-left + 通栏贴边 + 无圆角无阴影`。`--dsw-*` token 只当了 fallback，
+   多数颜色硬编码。
+3. **控制区过载**：head 一排 9 个文字按钮 + 标签行 + footer 行；DSH 风格是
+   icon-button + 克制的状态行。
+4. **画面层**：`<img>` + MJPEG：断流要重挂 src（闪断）、无缩放/平移、
+   letterbox 黑边、码率不可调、无操作可视化。
+5. **空态弱**：浏览器没起时只有一个按钮 + 一段小字。
+
+## 二、三档改造方向
+
+### A 档 · 形态贴合（低风险，约 1 天，只改 client.js）
+- 面板改「贴边 dock 列」外观：`right:0; top:0; bottom:0`，无圆角无大阴影，
+  `border-left:1px solid var(--dsw-alias-border-l2)`，背景
+  `var(--dsw-alias-bg-layer-1)`——视觉上就是第四列，不挡聊天。
+- 头部对齐 DSH 细节列：标题 + 折叠钮，工具栏全部 icon-button（用 `--dsw-*`
+  fill/border/label token），去掉文字按钮；折叠态 = 右侧贴边小圆钮。
+- 全部颜色/字体/圆角只走 `--dsw-*`（alias 集：bg-base/layer-1/layer-2、
+  border-l1..l3、label-primary..tertiary、fill-l2/l3、button-floating-*、
+  state-success/error/warn），不留硬编码 hex。
+- 空态重做（icon + 标题 + 副文案 + 主按钮），footer 只留「推流/轮询/空闲 +
+  视口」。
+
+### B 档 · 渲染与交互升级（中风险，2–3 天，改两端）
+- 传输：MJPEG `<img>` → **WebSocket + Canvas**。协议直接照抄
+  vercel-labs/agent-browser（见下）：`{type:"frame",seq,data,metadata}` +
+  `{type:"status"}`，输入走同一 socket；**最新帧优先 + ack pacing**（服务端只
+  发最新帧、客户端回 seq ack），彻底解决积压与断流闪断（canvas 保留上一帧）。
+- 画面交互：滚轮默认滚页面，Ctrl+滚轮或工具栏缩放；Fit/100%/滑杆；Figma 式
+  平移（空格或中键拖）。
+- **三态接管**（抄 gsd-browser Live Viewer）：`AI 在操作 | 你接管 | 只读`。
+  接管时高亮边框 + 顶部状态横幅；对招聘场景很实用——agent 跑寻源时盯着看，
+  关键时刻自己上手。
+- 可选：帧上叠加操作标记（点击闪光/坐标十字）。当前 agent 通过 bash 驱动
+  boss-cli，host 拿不到动作，需等 C 档或接 boss-cli 事件。
+
+### C 档 · 原生工具卡片（最贴 DSH 形态，大改，4–5 天）
+- 把"浏览器操作"从 bash 调 boss-cli 升级为 host 注册的真 Tool（dsh tools
+  注册表）。agent 每次操作在会话里渲染成**原生 tool card**（注册
+  `tool.call.toolview` keyed 插槽，参照 web_search 卡片写法）：卡片内实时帧
+  快照 + 状态 + 「打开面板」按钮；右侧面板降级为深查视图。
+- 这才是真正"长在 DSH 形态里"，但需要重排 agent 调用方式 + host 注册 tool +
+  client 注册 toolview。
+
+## 三、社区方案（可直接抄/结合）
+
+| 项目 | 做法 | 抄哪 |
+|---|---|---|
+| [vercel-labs/agent-browser](https://agent-browser.dev/streaming) | CDP 浏览器 + WebSocket 推流协议：frame/status/input 同 socket，最新帧优先 + ack pacing + seq | B 档传输层整份照抄 |
+| [open-gsd/gsd-browser](https://github.com/open-gsd/gsd-browser) | Rust CDP daemon + Live Viewer：human takeover、annotation 标记、goal banner、command history、录制 | B 档三态接管 + 状态横幅 |
+| [kasmtech/noVNC (KasmVNC)](https://github.com/kasmtech/noVNC) | WebP/JPEG 自动混用、按画面变化率动态调质量、IME、双向剪贴板 | B 档编码策略/帧率自适应 |
+| [browser-use/web-ui](https://github.com/browser-use/web-ui) | Gradio UI + 复用本机浏览器 profile（BROWSER_PATH/BROWSER_USER_DATA）+ 持久会话 + 录制 | profile 复用已做；录制/回放可抄 |
+| [zulfikawr/vbrowser](https://github.com/zulfikawr/vbrowser) / [m1k1o/neko](https://github.com/m1k1o/neko) / [selkies](https://github.com/selkies-project/selkies) | WebRTC 推流浏览器（60fps 低延迟） | 局域网单用户过重；未来做远程/多端再说 |
+| [OpenClaw browser tool](https://docs.openclaw.ai/tools/browser) | 浏览器自动化 skill 循环（先 status/tabs 再操作、snapshot 前后对比、登录/验证码交人工） | 面板的「agent 状态」叙事参考 |
+
+DSH 生态本身没有现成浏览器面板插件（harness 还是 rc，插件生态刚起步，
+[GitHub](https://github.com/deepseek-ai/deepseek-harness) 5k star）；当前
+profile bundle 模式（webServer 路由 + shell.overlay）就是官方认可的扩展方式，
+不用换框架。
+
+## 四、落地顺序建议
+
+1. **A 档**（形态贴合）——立即可做，解决"不像 DSH"的主要观感。
+2. **B 档**（WS+Canvas + 三态接管）——解决"不好用"（卡顿/闪断/不可缩放）。
+3. **C 档**（原生 tool 卡片）——想让它彻底长进聊天流再做，成本最高。
+
+推荐先做 A + B 里"WS 传输 + 三态接管"。C 档需要重排 agent 调用方式，单列评估。
+
+## 五、社区对标补充：dsh-better-sidebar（2026-08-14）
+
+[dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（v0.11.0）是社区里最接近
+"把 DSH 变成 IDE 工作台"的插件：右侧栏 + 底部面板双工作台（文件树/编辑器/终端/Git/Diff/
+子代理/浏览器 tab/9 种文件预览），工程质量高（TS + ~40 测试 + 设计文档 + i18n + 懒加载 +
+信任围栏）。评估结论：
+
+- **它的浏览器 tab 是沙箱 iframe**（无登录态、反嵌入站点进不去），对 BOSS 直聘场景无用；
+  我们的 CDP 镜像真浏览器仍是正解，不用换。
+- **最值得抄的是 layout-push 手法**：`#root { margin-right: var(--dsh-sidebar-width) }`，
+  面板打开时应用真正让出宽度，聊天不被遮挡。已在本轮 A 档实施（`--rcp-dock-width`）。
+- **可选的结合方式**：它暴露 `ctx.betterSidebar.registerTab()`，我们的面板可注册成
+  `recruiting:boss-browser` tab 白拿 dock/tab 栏/会话持久化；代价是引入大依赖（node-pty
+  原生二进制、Univer 23MB、全局链接拦截）和 DSH 升级断裂风险（依赖 `#root` DOM 结构）。
+- 结论：轻量路径（抄手法，自研 dock）已实施；重型路径（装它 + registerTab）留给用户决定
+  是否需要整个 IDE 工作台。
+
+## 六、实施记录
+
+### A 档 · 形态贴合（2026-08-14 已实施，仅 client.js）
+
+- dock 推挤：`#root { margin-right: var(--rcp-dock-width) }`（借鉴 dsh-better-sidebar），
+  折叠/整屏时归零；拖宽时禁用过渡（`body[data-rcp-dragging]`）。
+- 面板改贴边列：无圆角无阴影、左边框；背景/边框/文字/按钮/状态色全走 `--dsw-*` token
+  （含 `--ds-font-family-code` / `--ds-transition-duration-slow` / `--ds-ease-in-out`）。
+- 工具栏 icon-button 化（24px 方形、hover 高亮、data-on 态）；footer 只留
+  「视口×尺寸 · 推流/轮询/空闲 + 唤起窗口」；空态重做（图标 + 主色 CTA）。
+- 面板宽度默认 42% / 720px，记忆到 localStorage（`rcp.panel.width`），刷新恢复。
+- 验证：`node --check client.js` 通过；`node --test tests/mirror.test.mjs` 10/10 通过。
+  等待用户在 3080 硬刷新后回收手感反馈。
+
+### host 补丁：启动按钮与空态报错（2026-08-14，lib/index.js，需重启生效）
+
+排查「浏览器未运行 + cdp not connected」时发现启动按钮在当前配置下从未真正可用：
+`dsh/cordis.patch.yml` 的 boss 源没写 `userDataDir`，而 patch 提供的 `config.sources`
+整组覆盖了 `DEFAULT_SOURCES`，导致 `launch()` 拒绝拉起。一并修复：
+
+- 新增 `normalizeSources()`：patch 配置按源与内置默认合并（只写差异），
+  userDataDir/homeUrl 自动补上；未知源（如未来 liepin）原样保留。
+- 探针失败（浏览器没在跑）时清空 `state.error`：空态不再挂误导性的
+  "cdp not connected"。
+- 启动超时 15s 自动复位 `launching` 并给出明确错误，不再永远转圈。
+- 新增 3 个单测，`node --test tests/mirror.test.mjs` 13/13 通过。
+
+### 根因定位：Runtime.enable 触发 BOSS 反爬杀浏览器（2026-08-14）
+
+"浏览器崩溃"最终定位为**不是 Chrome bug，是 BOSS 反爬**：镜像连接时发送的
+`Runtime.enable` 被页面安全模块（zhipin-security WASM）当成调试器挂载信号，
+主动关掉整个浏览器，并把 profile 标记为异常（表现为反复要求重新登录）。
+证据（本机 Claude Code + 本会话多轮复测，拷贝 profile）：
+- 只开 `Runtime.enable`、不抓帧 → 0/4 存活；
+- 不开 `Runtime.enable`、screencast+screenshot 全量抓帧 → 4/4 存活。
+
+修复（lib/index.js）：连接序列去掉 `Runtime.enable`（镜像不消费 Runtime 事件，
+`Runtime.evaluate` 等命令不需要 enable）。⚠️ 教训：后续任何对 boss 登录态的
+测试一律用拷贝 profile，绝不直接操作真实 profile。
+
+### 附加：崩溃自愈 watch（2026-08-14，lib/index.js + client.js）
+
+面板未折叠时向 host 发 `control("watch")`；镜像在「曾连上过 + 在盯梢 +
+冷却 10s」时自动重新拉起意外掉线的浏览器。与根因修复配套，等重启生效。
+
+### 贴合改固定视口 958×1149（2026-08-14，client.js，硬刷新即生效）
+
+用户反馈"截得不够全、958×1149 刚好"：贴合不再跟随面板尺寸，页面视口固定为
+`FIXED_VIEWPORT = { width: 958, height: 1149 }`（client.js 常量），面板拖宽只
+影响显示缩放；黑边坐标由 normalize() 兜底。硬刷新即生效，无需重启 host。

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,37 +2,138 @@
  * recruiting-copilot —— DeepSeek Harness 宿主插件（node 半区）
  *
  * 把 boss-cli / liepin-cli 驱动的本机 Chrome 通过 Chrome DevTools Protocol
- * （CDP）实时镜像成 JPEG 帧，经 DSH Web 服务器暴露给右侧浏览器面板：
+ * （CDP）做成一只**可远程操作**的浏览器，经 DSH Web 服务器暴露给右侧面板：
  *
- *   GET /plugins/recruiting-view/state.json         —— 各浏览器源的状态 + 标签列表
- *   GET /plugins/recruiting-view/frame.jpg?source=X —— 最新一帧 JPEG（客户端轮询）
- *   GET /plugins/recruiting-view/set-target?source=X&pageId=Y —— 切换抓取目标标签
+ *   GET  /plugins/recruiting-view/state.json   —— 各源状态 + 标签列表 + 视口尺寸
+ *   GET  /plugins/recruiting-view/stream.mjpg  —— MJPEG 实时流（screencast 推帧）
+ *   GET  /plugins/recruiting-view/frame.jpg    —— 最新一帧（兜底/调试）
+ *   POST /plugins/recruiting-view/input        —— 鼠标/滚轮/键盘/文本注入
+ *   POST /plugins/recruiting-view/control      —— 启动浏览器、导航、切标签、贴合视口
  *
- * boss-cli 固定占用 53470 端口（见 boss-cli/src/browser/cdp_browser.ts：
+ * 帧来源优先 Page.startScreencast（有变化才推，空闲零开销）；窗口被遮挡/最小化
+ * 导致 screencast 停推时，看门狗自动回落到 Page.captureScreenshot 定时抓帧。
+ *
+ * boss-cli 固定占用 53470 端口（boss-cli/src/browser/cdp_browser.ts 的
  * REMOTE_DEBUGGING_PORT，可用 BOSS_BROWSER_REMOTE_DEBUGGING_PORT 覆盖），浏览器
- * 跨命令常驻，因此本插件可以并行挂到同一只浏览器上。
- * liepin-cli 目前用 puppeteer.launch() 且不带固定调试端口，暂不可挂载；
- * 等 liepin-cli 支持固定端口后，在 profile 配置的 sources 里加一项即可。
+ * 跨命令常驻；浏览器没起时本插件可用相同 user-data-dir 与端口自行拉起，之后
+ * boss-cli 会直连这只已存在的实例（同一登录态）。
  *
- * 无第三方依赖：只使用 Node 内置 fetch / WebSocket（Node ≥ 22）。
+ * 无第三方依赖：只用 Node 内置 fetch / WebSocket / child_process（Node ≥ 22）。
  */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 
 const NAME = "recruiting-copilot";
 /** 不声明 inject：webServer 仅 web profile 存在，headless 等 profile 下优雅降级。 */
 const inject = [];
 
-const DEFAULT_SOURCES = [{ name: "boss", port: 53470, match: /zhipin\.com/i }];
+/** 与 boss-cli 对齐的浏览器启动参数（详见其 cdp_browser.ts / puppeteer.defaultArgs）。 */
+const CHROME_LAUNCH_ARGS = [
+  "--allow-pre-commit-input",
+  "--disable-background-networking",
+  "--disable-background-timer-throttling",
+  "--disable-backgrounding-occluded-windows",
+  "--disable-breakpad",
+  "--disable-client-side-phishing-detection",
+  "--disable-component-extensions-with-background-pages",
+  "--disable-crash-reporter",
+  "--disable-default-apps",
+  "--disable-dev-shm-usage",
+  "--disable-hang-monitor",
+  "--disable-infobars",
+  "--disable-ipc-flooding-protection",
+  "--disable-popup-blocking",
+  "--disable-prompt-on-repost",
+  "--disable-renderer-backgrounding",
+  "--disable-search-engine-choice-screen",
+  "--disable-sync",
+  "--force-color-profile=srgb",
+  "--metrics-recording-only",
+  "--no-first-run",
+  "--password-store=basic",
+  "--use-mock-keychain",
+  "--disable-features=Translate,AcceptCHFrame,MediaRouter,OptimizationHints,WebUIReloadButton,ProcessPerSiteUpToMainFrameThreshold,IsolateSandboxedIframes",
+  "--disable-extensions"
+];
+
+const DEFAULT_SOURCES = [
+  {
+    name: "boss",
+    port: 53470,
+    match: /zhipin\.com/i,
+    homeUrl: "https://www.zhipin.com/web/chat/index",
+    userDataDir: path.join(homedir(), ".boss-cli", ".cache", "browser-data")
+  }
+];
 
 const PROBE_TIMEOUT_MS = 900;
 const COMMAND_TIMEOUT_MS = 6000;
+/** screencast 静默超过这个时长就回落到主动截图（窗口最小化/被遮挡时会静默）。 */
+const SCREENCAST_STALL_MS = 2500;
+/** 拉起浏览器后探针超过这个时长仍未就绪，判定启动失败（复位 launching）。 */
+const LAUNCH_TIMEOUT_MS = 15000;
+
+/**
+ * 合并 patch 配置与内置默认：patch 里的 source 只写差异（port/match），
+ * userDataDir / homeUrl 等默认从 DEFAULT_SOURCES 补上；同名源不存在时
+ * 原样保留（如未来的 liepin 源，仍由构造函数给兜底值）。
+ */
+function normalizeSources(configSources) {
+  const list = Array.isArray(configSources) && configSources.length > 0 ? configSources : DEFAULT_SOURCES;
+  return list.map((source) => ({ ...DEFAULT_SOURCES.find((d) => d.name === source.name), ...source }));
+}
 
 function clampInt(value, fallback, min, max) {
   const n = Number.parseInt(value, 10);
   return Number.isFinite(n) && n >= min && n <= max ? n : fallback;
 }
 
+function clampNum(value, fallback, min, max) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= min && n <= max ? n : fallback;
+}
+
+/** 常见 Chrome / Edge 安装位置（与 boss-cli 的探测顺序一致）。 */
+function findChromeExecutable() {
+  const fromEnv = process.env.CHROME_PATH?.trim() || process.env.PUPPETEER_EXECUTABLE_PATH?.trim();
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  const candidates = [];
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA;
+    const pf = process.env.PROGRAMFILES;
+    const pf86 = process.env["PROGRAMFILES(X86)"];
+    if (local) candidates.push(path.join(local, "Google", "Chrome", "Application", "chrome.exe"));
+    if (pf) {
+      candidates.push(path.join(pf, "Google", "Chrome", "Application", "chrome.exe"));
+      candidates.push(path.join(pf, "Microsoft", "Edge", "Application", "msedge.exe"));
+    }
+    if (pf86) {
+      candidates.push(path.join(pf86, "Google", "Chrome", "Application", "chrome.exe"));
+      candidates.push(path.join(pf86, "Microsoft", "Edge", "Application", "msedge.exe"));
+    }
+  } else if (process.platform === "darwin") {
+    candidates.push(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    );
+  } else {
+    candidates.push(
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/google-chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+      "/usr/bin/microsoft-edge-stable"
+    );
+  }
+  return candidates.find((p) => existsSync(p)) ?? null;
+}
+
 /**
- * 一个浏览器源（如 boss）的镜像：探测 CDP 端点 → 连接目标页 → 周期截图。
+ * 一个浏览器源（如 boss）的镜像：探测 CDP → 连接目标页 → 推帧 + 收输入。
  * 所有错误都被吞进 state.error，不影响宿主进程。
  */
 export class BrowserMirror {
@@ -40,15 +141,24 @@ export class BrowserMirror {
     this.name = source.name;
     this.port = clampInt(source.port, 53470, 1, 65535);
     this.match = source.match instanceof RegExp ? source.match : new RegExp(source.match ?? "", "i");
-    this.quality = clampInt(config.jpegQuality, 60, 10, 95);
+    this.homeUrl = typeof source.homeUrl === "string" ? source.homeUrl : "about:blank";
+    this.userDataDir = typeof source.userDataDir === "string" ? source.userDataDir : null;
+    this.quality = clampInt(config.jpegQuality, 80, 10, 100);
+    this.maxWidth = clampInt(config.maxFrameWidth, 1800, 320, 4096);
     this.state = {
       name: this.name,
       connected: false,
+      launching: false,
       browser: null,
       pages: [],
       targetId: null,
       targetTitle: null,
       targetUrl: null,
+      /** 页面 CSS 视口尺寸：客户端据此把面板坐标换算成页面坐标。 */
+      viewport: { width: 0, height: 0 },
+      /** 当前是否用 Emulation 把页面视口贴合到了面板尺寸。 */
+      fitted: false,
+      frameMode: "idle",
       lastFrameAt: 0,
       seq: 0,
       error: null
@@ -58,18 +168,55 @@ export class BrowserMirror {
     this._pending = new Map();
     this._commandSeq = 0;
     this._targetOverride = null;
-    this._lastCaptureAt = 0;
+    this._frame = null;
+    this._subscribers = new Set();
+    this._lastScreencastAt = 0;
+    this._lastPollAt = 0;
+    this._lastListAt = 0;
+    this._fitRequest = null;
+    this._appliedFit = null;
+    this._clearedOnce = false;
+    this._launchingSince = 0;
+    this._everConnected = false;
+    this._watch = false;
+    this._relaunchAt = 0;
+  }
+
+  /** 面板是否在盯梢：打开时崩溃后自动重新拉起浏览器。 */
+  setWatch(on) {
+    this._watch = on === true;
   }
 
   /** 切换抓取目标（pageId 来自 state.pages[].id）。 */
   setTarget(pageId) {
     this._targetOverride = pageId || null;
+    this._appliedFit = null;
     this._dropConnection();
   }
 
-  /** 抓到的最后一帧（JPEG Buffer），没有则 undefined。 */
+  /** 抓到的最后一帧（JPEG Buffer），没有则 null。 */
   get frame() {
     return this._frame;
+  }
+
+  /** MJPEG 订阅：返回退订函数。 */
+  subscribe(sink) {
+    this._subscribers.add(sink);
+    if (this._frame) sink(this._frame);
+    return () => this._subscribers.delete(sink);
+  }
+
+  _publish(buf) {
+    this._frame = buf;
+    this.state.lastFrameAt = Date.now();
+    this.state.seq += 1;
+    for (const sink of this._subscribers) {
+      try {
+        sink(buf);
+      } catch {
+        this._subscribers.delete(sink);
+      }
+    }
   }
 
   _dropConnection() {
@@ -80,6 +227,7 @@ export class BrowserMirror {
       this._ws = null;
     }
     this._wsTargetId = null;
+    this.state.frameMode = "idle";
   }
 
   async _probe() {
@@ -104,7 +252,9 @@ export class BrowserMirror {
       const res = await fetch(`http://127.0.0.1:${this.port}/json/list`, { signal: ctrl.signal });
       if (!res.ok) return [];
       const targets = await res.json();
-      return (Array.isArray(targets) ? targets : []).filter((t) => t?.type === "page" && !String(t.url ?? "").startsWith("chrome://") && !String(t.title ?? "").startsWith("chrome://"));
+      return (Array.isArray(targets) ? targets : []).filter(
+        (t) => t?.type === "page" && !String(t.url ?? "").startsWith("chrome://") && !String(t.title ?? "").startsWith("chrome://")
+      );
     } catch {
       return [];
     } finally {
@@ -118,6 +268,29 @@ export class BrowserMirror {
     return (matched ?? pages[0])?.id ?? null;
   }
 
+  _onEvent(msg) {
+    if (msg.method === "Page.screencastFrame") {
+      const meta = msg.params?.metadata ?? {};
+      const width = Math.round(Number(meta.deviceWidth) || 0);
+      const height = Math.round(Number(meta.deviceHeight) || 0);
+      if (width > 0 && height > 0) this.state.viewport = { width, height };
+      this._lastScreencastAt = Date.now();
+      this.state.frameMode = "screencast";
+      if (msg.params?.sessionId !== undefined) {
+        this._command("Page.screencastFrameAck", { sessionId: msg.params.sessionId });
+      }
+      if (typeof msg.params?.data === "string" && msg.params.data.length > 0) {
+        const buf = Buffer.from(msg.params.data, "base64");
+        if (buf.length > 0) this._publish(buf);
+      }
+      return;
+    }
+    if (msg.method === "Page.frameNavigated" && msg.params?.frame?.parentId === undefined) {
+      this.state.targetUrl = msg.params.frame.url ?? this.state.targetUrl;
+      this._lastListAt = 0; // 触发下一轮刷新标签标题
+    }
+  }
+
   async _ensureConnected() {
     const version = await this._probe();
     if (!version) {
@@ -125,12 +298,26 @@ export class BrowserMirror {
       this.state.browser = null;
       this.state.pages = [];
       this.state.targetId = null;
+      this.state.viewport = { width: 0, height: 0 };
+      this.state.fitted = false;
+      // 浏览器没在跑不是错误：清掉上次连接受损留下的误导性报错（如
+      // "cdp not connected"），空态文案自己会说明该启动浏览器。
+      this.state.error = null;
+      this._appliedFit = null;
       this._dropConnection();
       return false;
     }
-    const pages = await this._listPages();
+    this.state.launching = false;
     this.state.browser = version.Browser ?? version.browser ?? "unknown";
-    this.state.pages = pages.map((p) => ({ id: p.id, title: p.title ?? "", url: p.url ?? "" }));
+
+    const needList = Date.now() - this._lastListAt > 2000 || this._ws === null;
+    let pages = this._rawPages ?? [];
+    if (needList) {
+      pages = await this._listPages();
+      this._rawPages = pages;
+      this._lastListAt = Date.now();
+      this.state.pages = pages.map((p) => ({ id: p.id, title: p.title ?? "", url: p.url ?? "" }));
+    }
     const targetId = this._pickTarget(pages);
     this.state.targetId = targetId;
     if (targetId === null) {
@@ -140,12 +327,12 @@ export class BrowserMirror {
     }
     const target = pages.find((p) => p.id === targetId);
     this.state.targetTitle = target?.title ?? null;
-    this.state.targetUrl = target?.url ?? null;
+    if (needList) this.state.targetUrl = target?.url ?? null;
 
     if (this._ws && this._wsTargetId === targetId && this._ws.readyState === 1) return true;
 
     this._dropConnection();
-    const wsUrl = target.webSocketDebuggerUrl;
+    const wsUrl = target?.webSocketDebuggerUrl;
     if (!wsUrl) return false;
 
     await new Promise((resolve, reject) => {
@@ -177,13 +364,16 @@ export class BrowserMirror {
           this._pending.delete(msg.id);
           clearTimeout(t);
           done(msg);
+          return;
         }
+        if (typeof msg?.method === "string") this._onEvent(msg);
       });
       ws.addEventListener("close", () => {
         if (this._ws === ws) {
           this._ws = null;
           this._wsTargetId = null;
           this.state.connected = false;
+          this.state.frameMode = "idle";
         }
         for (const { resolve: done, timer: t } of this._pending.values()) {
           clearTimeout(t);
@@ -195,8 +385,16 @@ export class BrowserMirror {
 
     try {
       await this._command("Page.enable", {});
+      // 注意：不要发 Runtime.enable —— BOSS 反爬模块把它当调试器挂载信号，
+      // 会主动杀掉整个浏览器（实测 0/4 存活）；不开它抓帧 4/4 全活。
+      // Runtime.evaluate 等命令不需要 enable 也能用（镜像也不消费 Runtime 事件）。
+      this._appliedFit = null;
+      this._clearedOnce = false;
+      await this._applyFit();
+      await this._startScreencast();
       this.state.connected = true;
       this.state.error = null;
+      this._everConnected = true;
       return true;
     } catch (error) {
       this.state.connected = false;
@@ -204,6 +402,17 @@ export class BrowserMirror {
       this._dropConnection();
       return false;
     }
+  }
+
+  async _startScreencast() {
+    this._lastScreencastAt = Date.now();
+    await this._command("Page.startScreencast", {
+      format: "jpeg",
+      quality: this.quality,
+      maxWidth: this.maxWidth,
+      maxHeight: this.maxWidth,
+      everyNthFrame: 1
+    });
   }
 
   _command(method, params) {
@@ -228,36 +437,280 @@ export class BrowserMirror {
     });
   }
 
-  /** 一轮：确保连接 → 抓一帧（若有足够间隔）→ 更新状态。 */
+  /** 请求把页面视口贴合到面板尺寸（客户端传 CSS 尺寸）；width<=0 表示取消贴合。 */
+  requestFit(width, height, deviceScaleFactor) {
+    if (!(width > 0) || !(height > 0)) {
+      this._fitRequest = null;
+      return;
+    }
+    const next = {
+      width: clampInt(width, 1280, 320, 3840),
+      height: clampInt(height, 900, 320, 3840),
+      deviceScaleFactor: clampNum(deviceScaleFactor, 1.5, 1, 3)
+    };
+    const prev = this._fitRequest;
+    // 抖动过滤：宽高变化不足 12px 不重设，避免拖动面板时刷屏。
+    if (prev && Math.abs(prev.width - next.width) < 12 && Math.abs(prev.height - next.height) < 12 && prev.deviceScaleFactor === next.deviceScaleFactor) {
+      return;
+    }
+    this._fitRequest = next;
+  }
+
+  async _applyFit() {
+    const want = this._fitRequest;
+    const applied = this._appliedFit;
+    if (want === null) {
+      // 覆盖可能是上一条 CDP 会话留下的（Chrome 不保证断开即还原），所以每条新
+      // 会话在无贴合需求时都补发一次 clear，只发一次。
+      if (applied !== null || !this._clearedOnce) {
+        // 只发 clear 清不掉「别的（已断开）会话留下的」覆盖：先用 0 宽高把覆盖
+        // 接管到本会话名下，再 clear 才会真的还原成窗口实际尺寸。
+        await this._command("Emulation.setDeviceMetricsOverride", { width: 0, height: 0, deviceScaleFactor: 0, mobile: false });
+        await this._command("Emulation.clearDeviceMetricsOverride", {});
+        this._appliedFit = null;
+        this._clearedOnce = true;
+        this.state.fitted = false;
+      }
+      return;
+    }
+    if (applied && applied.width === want.width && applied.height === want.height && applied.deviceScaleFactor === want.deviceScaleFactor) {
+      return;
+    }
+    const msg = await this._command("Emulation.setDeviceMetricsOverride", {
+      width: want.width,
+      height: want.height,
+      deviceScaleFactor: want.deviceScaleFactor,
+      mobile: false,
+      screenWidth: want.width,
+      screenHeight: want.height
+    });
+    if (msg?.error) {
+      this.state.error = msg.error.message ?? "fit failed";
+      return;
+    }
+    this._appliedFit = want;
+    this._clearedOnce = false;
+    this.state.fitted = true;
+    this.state.viewport = { width: want.width, height: want.height };
+  }
+
+  /** 主动抓一帧（screencast 静默时的兜底路径）。 */
+  async _pollFrame() {
+    const msg = await this._command("Page.captureScreenshot", { format: "jpeg", quality: this.quality, fromSurface: true });
+    const data = msg?.result?.data
+      ?? (await this._command("Page.captureScreenshot", { format: "jpeg", quality: this.quality, fromSurface: false }))?.result?.data;
+    if (typeof data === "string" && data.length > 0) {
+      const buf = Buffer.from(data, "base64");
+      if (buf.length > 0) {
+        this.state.frameMode = "poll";
+        this._publish(buf);
+      }
+    }
+  }
+
+  /** 页面 CSS 视口（贴合模式下即面板尺寸；否则读真实窗口）。 */
+  async _refreshViewport() {
+    if (this.state.viewport.width > 0 && this.state.frameMode === "screencast") return;
+    const msg = await this._command("Runtime.evaluate", {
+      expression: "JSON.stringify({w:innerWidth,h:innerHeight})",
+      returnByValue: true
+    });
+    try {
+      const { w, h } = JSON.parse(msg?.result?.result?.value ?? "{}");
+      if (w > 0 && h > 0) this.state.viewport = { width: Math.round(w), height: Math.round(h) };
+    } catch { /* ignore */ }
+  }
+
+  /** 看门狗一轮：保连接 → 应用贴合 → screencast 静默时兜底抓帧。 */
   async tick() {
     try {
       const ok = await this._ensureConnected();
-      if (!ok) return;
-      const now = Date.now();
-      if (now - this._lastCaptureAt < 600) return; // 与 frameIntervalMs 配合限速
-      const msg = await this._command("Page.captureScreenshot", {
-        format: "jpeg",
-        quality: this.quality,
-        fromSurface: true
-      });
-      if (msg?.result?.data) {
-        const buf = Buffer.from(msg.result.data, "base64");
-        if (buf.length > 0) {
-          this._frame = buf;
-          this.state.lastFrameAt = Date.now();
-          this.state.seq += 1;
-          this._lastCaptureAt = Date.now();
+      if (!ok) {
+        // 启动后探针迟迟不就绪：复位 launching，免得空态永远转圈。
+        if (this.state.launching && Date.now() - this._launchingSince > LAUNCH_TIMEOUT_MS) {
+          this.state.launching = false;
+          this.state.error = `浏览器启动超时：端口 ${this.port} 未就绪（检查是否有别的实例占用 boss profile）`;
         }
-      } else {
-        this.state.error = msg?.error?.message ?? "capture failed";
+        // 自愈：面板在盯梢（watch）且浏览器曾连上过、又意外掉线（崩溃等），
+        // 冷却后自动重新拉起；冷启动（从没连上过）仍走面板按钮。
+        if (this._everConnected && this._watch && !this.state.launching && Date.now() - this._relaunchAt > 10000) {
+          this._relaunchAt = Date.now();
+          await this.launch();
+        }
+        return;
       }
+      await this._applyFit();
+      const now = Date.now();
+      const stalled = now - this._lastScreencastAt > SCREENCAST_STALL_MS;
+      if (stalled && this._subscribers.size > 0 && now - this._lastPollAt > 700) {
+        this._lastPollAt = now;
+        await this._pollFrame();
+        // 顺手重开一次 screencast：窗口重新可见后能自动回到推流模式。
+        if (now - this._lastScreencastAt > SCREENCAST_STALL_MS * 4) await this._startScreencast();
+      }
+      await this._refreshViewport();
     } catch (error) {
       this.state.error = String(error?.message ?? error);
       this.state.connected = false;
     }
   }
 
+  /** 面板坐标（0..1 归一化）→ 页面 CSS 坐标。 */
+  _toPageXY(nx, ny) {
+    const vw = this.state.viewport.width || 1280;
+    const vh = this.state.viewport.height || 900;
+    return {
+      x: Math.max(0, Math.min(vw, clampNum(nx, 0, -1, 2) * vw)),
+      y: Math.max(0, Math.min(vh, clampNum(ny, 0, -1, 2) * vh))
+    };
+  }
+
+  /** 批量派发输入事件（顺序即 TCP 顺序，不等回执）。 */
+  dispatchInput(events) {
+    if (!Array.isArray(events)) return 0;
+    let sent = 0;
+    for (const ev of events.slice(0, 200)) {
+      if (!ev || typeof ev !== "object") continue;
+      if (ev.kind === "mouse") {
+        const { x, y } = this._toPageXY(ev.nx, ev.ny);
+        const vw = this.state.viewport.width || 1280;
+        const vh = this.state.viewport.height || 900;
+        const params = {
+          type: ev.type,
+          x,
+          y,
+          button: ev.button ?? "none",
+          buttons: clampInt(ev.buttons, 0, 0, 31),
+          clickCount: clampInt(ev.clickCount, 0, 0, 3),
+          modifiers: clampInt(ev.modifiers, 0, 0, 15)
+        };
+        if (ev.type === "mouseWheel") {
+          params.deltaX = clampNum(ev.ndx, 0, -10, 10) * vw;
+          params.deltaY = clampNum(ev.ndy, 0, -10, 10) * vh;
+        }
+        this._command("Input.dispatchMouseEvent", params);
+        sent += 1;
+        continue;
+      }
+      if (ev.kind === "key") {
+        this._command("Input.dispatchKeyEvent", {
+          type: ev.type,
+          key: typeof ev.key === "string" ? ev.key : undefined,
+          code: typeof ev.code === "string" ? ev.code : undefined,
+          windowsVirtualKeyCode: clampInt(ev.keyCode, 0, 0, 255),
+          nativeVirtualKeyCode: clampInt(ev.keyCode, 0, 0, 255),
+          text: typeof ev.text === "string" ? ev.text : undefined,
+          unmodifiedText: typeof ev.text === "string" ? ev.text : undefined,
+          autoRepeat: ev.autoRepeat === true,
+          isKeypad: ev.isKeypad === true,
+          location: clampInt(ev.location, 0, 0, 3),
+          modifiers: clampInt(ev.modifiers, 0, 0, 15)
+        });
+        sent += 1;
+        continue;
+      }
+      if (ev.kind === "text" && typeof ev.text === "string" && ev.text.length > 0) {
+        this._command("Input.insertText", { text: ev.text.slice(0, 4096) });
+        sent += 1;
+      }
+    }
+    return sent;
+  }
+
+  async navigate(url) {
+    if (typeof url !== "string" || url.length === 0) return { ok: false, error: "empty url" };
+    const target = /^[a-z]+:\/\//i.test(url) ? url : `https://${url}`;
+    const msg = await this._command("Page.navigate", { url: target });
+    return msg?.error ? { ok: false, error: msg.error.message } : { ok: true };
+  }
+
+  async reload() {
+    await this._command("Page.reload", {});
+    return { ok: true };
+  }
+
+  /** 前进/后退：读导航历史后跳到相邻条目。 */
+  async history(delta) {
+    const msg = await this._command("Page.getNavigationHistory", {});
+    const entries = msg?.result?.entries;
+    const index = msg?.result?.currentIndex;
+    if (!Array.isArray(entries) || typeof index !== "number") return { ok: false, error: "no history" };
+    const next = index + delta;
+    if (next < 0 || next >= entries.length) return { ok: false, error: "history boundary" };
+    await this._command("Page.navigateToHistoryEntry", { entryId: entries[next].id });
+    return { ok: true };
+  }
+
+  async bringToFront() {
+    await this._command("Page.bringToFront", {});
+    return { ok: true };
+  }
+
+  async newTab(url) {
+    const target = typeof url === "string" && url.length > 0 ? url : this.homeUrl;
+    try {
+      const res = await fetch(`http://127.0.0.1:${this.port}/json/new?${encodeURIComponent(target)}`, { method: "PUT" });
+      if (!res.ok) return { ok: false, error: `new tab: HTTP ${res.status}` };
+      const created = await res.json();
+      this._lastListAt = 0;
+      if (created?.id) this.setTarget(created.id);
+      return { ok: true, id: created?.id ?? null };
+    } catch (error) {
+      return { ok: false, error: String(error?.message ?? error) };
+    }
+  }
+
+  async closeTab(pageId) {
+    if (typeof pageId !== "string" || pageId.length === 0) return { ok: false, error: "no pageId" };
+    try {
+      await fetch(`http://127.0.0.1:${this.port}/json/close/${encodeURIComponent(pageId)}`);
+      if (this._targetOverride === pageId) this._targetOverride = null;
+      this._lastListAt = 0;
+      this._dropConnection();
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: String(error?.message ?? error) };
+    }
+  }
+
+  /**
+   * 拉起浏览器：与 boss-cli 同一 user-data-dir 和调试端口，因此后续 boss 命令
+   * 会直连这只实例（同一登录态），不会另开一只。
+   */
+  async launch() {
+    if (this.state.connected) return { ok: true, already: true };
+    if (await this._probe()) return { ok: true, already: true };
+    if (!this.userDataDir) return { ok: false, error: `源「${this.name}」未配置 userDataDir，无法拉起浏览器` };
+    const exe = findChromeExecutable();
+    if (!exe) return { ok: false, error: "未找到本机 Chrome/Edge：请设置 CHROME_PATH" };
+    const args = [
+      ...CHROME_LAUNCH_ARGS,
+      `--user-data-dir=${this.userDataDir}`,
+      `--remote-debugging-port=${this.port}`,
+      this.homeUrl
+    ];
+    try {
+      const proc = spawn(exe, args, { detached: true, stdio: "ignore", env: process.env });
+      proc.unref();
+      this.state.launching = true;
+      this._launchingSince = Date.now();
+      this.state.error = null;
+      return { ok: true, pid: proc.pid ?? null };
+    } catch (error) {
+      return { ok: false, error: String(error?.message ?? error) };
+    }
+  }
+
   dispose() {
+    this._subscribers.clear();
+    // 插件卸载/DSH 退出时把视口还原，别让真实浏览器卡在面板尺寸。
+    if (this._appliedFit !== null) {
+      this._command("Emulation.setDeviceMetricsOverride", { width: 0, height: 0, deviceScaleFactor: 0, mobile: false });
+      this._command("Emulation.clearDeviceMetricsOverride", {});
+      this._command("Page.stopScreencast", {});
+      this._appliedFit = null;
+      this.state.fitted = false;
+    }
     this._dropConnection();
     for (const { resolve: done, timer: t } of this._pending.values()) {
       clearTimeout(t);
@@ -269,9 +722,72 @@ export class BrowserMirror {
 
 /** 按查询串取源名（默认 boss）。 */
 function sourceNameFrom(url) {
-  const q = new URLSearchParams(url?.search ?? "");
-  const name = q.get("source");
+  const name = url.searchParams.get("source");
   return typeof name === "string" && name.length > 0 ? name : "boss";
+}
+
+function readJsonBody(req, limitBytes = 256 * 1024) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let size = 0;
+    req.on("data", (chunk) => {
+      size += chunk.length;
+      if (size > limitBytes) {
+        req.destroy();
+        resolve(null);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      } catch {
+        resolve(null);
+      }
+    });
+    req.on("error", () => resolve(null));
+  });
+}
+
+function sendJson(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
+  res.end(JSON.stringify(body));
+}
+
+const MJPEG_BOUNDARY = "rcpframe";
+
+/** MJPEG 长连接：每来一帧写一段 multipart；写不动就丢帧，不排队。 */
+function streamMjpeg(mirror, req, res) {
+  res.writeHead(200, {
+    "content-type": `multipart/x-mixed-replace; boundary=${MJPEG_BOUNDARY}`,
+    "cache-control": "no-store, no-transform",
+    connection: "close",
+    pragma: "no-cache"
+  });
+  let backedUp = false;
+  res.on("drain", () => { backedUp = false; });
+  const unsubscribe = mirror.subscribe((buf) => {
+    if (backedUp || res.writableEnded) return;
+    const head = `--${MJPEG_BOUNDARY}\r\nContent-Type: image/jpeg\r\nContent-Length: ${buf.length}\r\n\r\n`;
+    res.write(head);
+    const ok = res.write(buf);
+    res.write("\r\n");
+    if (!ok) backedUp = true;
+  });
+  const stop = () => {
+    unsubscribe();
+    try {
+      res.end();
+    } catch { /* ignore */ }
+  };
+  req.on("close", stop);
+  req.on("error", stop);
+  res.on("error", stop);
 }
 
 /**
@@ -279,17 +795,25 @@ function sourceNameFrom(url) {
  * @param mirrors - 各浏览器源的 BrowserMirror 列表。
  */
 function makeRouteHandler(mirrors) {
-  return (req, res) => {
+  const pick = (url) => mirrors.find((m) => m.name === sourceNameFrom(url)) ?? mirrors[0];
+  return async (req, res) => {
     const url = new URL(req.url ?? "/", "http://dsh.local");
     const pathname = url.pathname;
+    const mirror = pick(url);
+
     if (pathname.endsWith("/state.json")) {
-      const body = JSON.stringify({ sources: mirrors.map((m) => m.state), ts: Date.now() });
-      res.writeHead(200, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
-      res.end(body);
+      sendJson(res, 200, { sources: mirrors.map((m) => m.state), ts: Date.now() });
+      return;
+    }
+    if (pathname.endsWith("/stream.mjpg")) {
+      if (!mirror) {
+        sendJson(res, 404, { ok: false, error: "no source" });
+        return;
+      }
+      streamMjpeg(mirror, req, res);
       return;
     }
     if (pathname.endsWith("/frame.jpg")) {
-      const mirror = mirrors.find((m) => m.name === sourceNameFrom(url)) ?? mirrors[0];
       const frame = mirror?.frame;
       if (!frame) {
         res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
@@ -300,11 +824,51 @@ function makeRouteHandler(mirrors) {
       res.end(frame);
       return;
     }
+    if (pathname.endsWith("/input")) {
+      const body = await readJsonBody(req);
+      if (body === null || !mirror) {
+        sendJson(res, 400, { ok: false, error: "bad input body" });
+        return;
+      }
+      const sent = mirror.dispatchInput(body.events);
+      sendJson(res, 200, { ok: true, sent, viewport: mirror.state.viewport });
+      return;
+    }
+    if (pathname.endsWith("/control")) {
+      const body = req.method === "POST" ? await readJsonBody(req) : {};
+      if (body === null || !mirror) {
+        sendJson(res, 400, { ok: false, error: "bad control body" });
+        return;
+      }
+      const action = String(body.action ?? url.searchParams.get("action") ?? "");
+      let result = { ok: false, error: `unknown action "${action}"` };
+      if (action === "launch") result = await mirror.launch();
+      else if (action === "navigate") result = await mirror.navigate(body.url);
+      else if (action === "reload") result = await mirror.reload();
+      else if (action === "back") result = await mirror.history(-1);
+      else if (action === "forward") result = await mirror.history(1);
+      else if (action === "activate") result = await mirror.bringToFront();
+      else if (action === "new-tab") result = await mirror.newTab(body.url);
+      else if (action === "close-tab") result = await mirror.closeTab(body.pageId);
+      else if (action === "set-target") {
+        mirror.setTarget(body.pageId);
+        result = { ok: true };
+      } else if (action === "fit") {
+        mirror.requestFit(body.width, body.height, body.deviceScaleFactor);
+        result = { ok: true };
+      } else if (action === "unfit") {
+        mirror.requestFit(0, 0, 1);
+        result = { ok: true };
+      } else if (action === "watch") {
+        mirror.setWatch(body.on === true);
+        result = { ok: true };
+      }
+      sendJson(res, result.ok ? 200 : 400, result);
+      return;
+    }
     if (pathname.endsWith("/set-target")) {
-      const mirror = mirrors.find((m) => m.name === sourceNameFrom(url)) ?? mirrors[0];
       mirror?.setTarget(url.searchParams.get("pageId"));
-      res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
-      res.end(JSON.stringify({ ok: true }));
+      sendJson(res, 200, { ok: true });
       return;
     }
     res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
@@ -313,16 +877,14 @@ function makeRouteHandler(mirrors) {
 }
 
 /**
- * cordis 插件主体：注册 /plugins/recruiting-view/* 路由并周期性抓帧。
+ * cordis 插件主体：注册 /plugins/recruiting-view/* 路由并跑镜像看门狗。
  * @param ctx - cordis 上下文。
  * @param rawConfig - profile 补丁里该 entry 的 config。
  */
 export function apply(ctx, rawConfig = {}) {
   const config = rawConfig ?? {};
-  const sources = Array.isArray(config.sources) && config.sources.length > 0
-    ? config.sources
-    : DEFAULT_SOURCES;
-  const intervalMs = clampInt(config.frameIntervalMs, 1000, 300, 30000);
+  const sources = normalizeSources(config.sources);
+  const intervalMs = clampInt(config.watchdogIntervalMs ?? config.frameIntervalMs, 700, 200, 30000);
   const mirrors = sources.map((source) => new BrowserMirror(source, config));
 
   const tick = () => {
@@ -356,4 +918,4 @@ export function apply(ctx, rawConfig = {}) {
   }, "recruiting-copilot: browser mirror");
 }
 
-export { NAME, inject };
+export { NAME, inject, normalizeSources };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "recruiting-copilot",
-  "version": "0.5.0",
-  "description": "AI 招聘副驾 —— DeepSeek Harness profile bundle：注册招聘工作流 skills（岗位梳理、双通道寻源初筛、约面试、简历评估、台账与日报），并在 Web UI 右侧提供 boss/liepin 浏览器实时镜像面板。",
+  "version": "0.6.0",
+  "description": "AI 招聘副驾 —— DeepSeek Harness profile bundle：注册招聘工作流 skills（岗位梳理、双通道寻源初筛、约面试、简历评估、台账与日报），并在 Web UI 右侧提供一只可直接操作的 boss/liepin 浏览器面板。",
   "keywords": [
     "recruiting",
     "deepseek-harness",
@@ -12,6 +12,9 @@
     "cdp"
   ],
   "type": "module",
+  "scripts": {
+    "test": "node --test \"tests/*.test.mjs\""
+  },
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js",

--- a/tests/harness-live.mjs
+++ b/tests/harness-live.mjs
@@ -1,0 +1,42 @@
+/**
+ * 本地联调 harness：不起 DSH，直接把 host 插件挂到一个裸 http 服务上，
+ * 用来验证 screencast 推流 / MJPEG / 输入派发 / control 动作是否真的通。
+ *
+ *   node tests/harness-live.mjs [port]
+ */
+import http from "node:http";
+import { apply } from "../lib/index.js";
+
+const port = Number(process.argv[2] ?? 3081);
+let handler = null;
+
+const ctx = {
+  inject(_deps, cb) {
+    cb({
+      webServer: {
+        register(route) {
+          handler = route.handler;
+          return () => { handler = null; };
+        }
+      },
+      effect(fn) { fn(); }
+    });
+  },
+  effect(fn) { fn(); }
+};
+
+apply(ctx, {});
+
+http.createServer((req, res) => {
+  if (handler && (req.url ?? "").startsWith("/plugins/recruiting-view")) {
+    Promise.resolve(handler(req, res)).catch((e) => {
+      res.writeHead(500);
+      res.end(String(e));
+    });
+    return;
+  }
+  res.writeHead(404);
+  res.end("not found");
+}).listen(port, "127.0.0.1", () => {
+  console.log(`harness on http://127.0.0.1:${port}/plugins/recruiting-view/state.json`);
+});

--- a/tests/input-e2e.mjs
+++ b/tests/input-e2e.mjs
@@ -1,0 +1,83 @@
+/**
+ * 端到端验证输入回传：自己开一条 CDP 在页面里装一个探针（记录收到的
+ * mousemove / keydown / wheel），再通过 harness 的 /input 发事件，读回探针结果。
+ * 用 F13 这种无副作用的键，不会在页面里留下任何输入。
+ *
+ *   node tests/input-e2e.mjs [harnessPort] [cdpPort]
+ */
+const harnessPort = Number(process.argv[2] ?? 3081);
+const cdpPort = Number(process.argv[3] ?? 53470);
+
+const targets = await (await fetch(`http://127.0.0.1:${cdpPort}/json/list`)).json();
+const page = targets.find((t) => t.type === "page" && /zhipin\.com/i.test(t.url ?? "")) ?? targets.find((t) => t.type === "page");
+if (!page) throw new Error("no page target");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => ws.addEventListener("open", r, { once: true }));
+let id = 0;
+const pending = new Map();
+ws.addEventListener("message", (e) => {
+  const msg = JSON.parse(String(e.data));
+  if (msg.id !== undefined && pending.has(msg.id)) {
+    pending.get(msg.id)(msg);
+    pending.delete(msg.id);
+  }
+});
+const send = (method, params) => new Promise((resolve) => {
+  const mid = ++id;
+  pending.set(mid, resolve);
+  ws.send(JSON.stringify({ id: mid, method, params }));
+});
+const evaluate = async (expression) => {
+  const r = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: false });
+  if (r?.result?.exceptionDetails) throw new Error(JSON.stringify(r.result.exceptionDetails.text));
+  return r?.result?.result?.value;
+};
+
+await evaluate(`(() => {
+  (window.__rcpHandlers ?? []).forEach(([t, f]) => window.removeEventListener(t, f, true));
+  window.__rcpProbe = { move: null, key: null, wheel: null, down: null };
+  const hMove = (e) => { window.__rcpProbe.move = { x: Math.round(e.clientX), y: Math.round(e.clientY) }; };
+  const hDown = (e) => { window.__rcpProbe.down = { x: Math.round(e.clientX), y: Math.round(e.clientY), button: e.button }; };
+  const hKey = (e) => { window.__rcpProbe.key = { key: e.key, code: e.code, keyCode: e.keyCode }; };
+  const hWheel = (e) => { window.__rcpProbe.wheel = { dy: Math.round(e.deltaY) }; };
+  window.__rcpHandlers = [['mousemove', hMove], ['mousedown', hDown], ['keydown', hKey], ['wheel', hWheel]];
+  window.__rcpHandlers.forEach(([t, f]) => window.addEventListener(t, f, true));
+  return 'probe installed';
+})()`);
+
+const post = (path, body) => fetch(`http://127.0.0.1:${harnessPort}/plugins/recruiting-view/${path}?source=boss`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body)
+}).then((r) => r.json());
+
+const viewport = (await post("input", { events: [] })).viewport;
+
+// 键盘事件只送到焦点元素；页面焦点常在 iframe 里，先把焦点拉回顶层文档再验。
+await evaluate("(() => { document.body.tabIndex = -1; document.body.focus(); return document.activeElement?.tagName; })()");
+
+await post("input", {
+  events: [
+    { kind: "mouse", type: "mouseMoved", nx: 0.111, ny: 0.132, buttons: 0 },
+    { kind: "mouse", type: "mouseWheel", nx: 0.111, ny: 0.132, ndx: 0, ndy: 0.3 },
+    { kind: "key", type: "rawKeyDown", key: "F13", code: "F13", keyCode: 124 },
+    { kind: "key", type: "keyUp", key: "F13", code: "F13", keyCode: 124 }
+  ]
+});
+await new Promise((r) => setTimeout(r, 800));
+const probe = await evaluate("JSON.stringify(window.__rcpProbe)");
+
+const expected = { x: Math.round(0.111 * viewport.width), y: Math.round(0.132 * viewport.height) };
+const got = JSON.parse(probe ?? "{}");
+console.log(JSON.stringify({
+  viewport,
+  expectedMove: expected,
+  probe: got,
+  moveOk: got.move && Math.abs(got.move.x - expected.x) <= 2 && Math.abs(got.move.y - expected.y) <= 2,
+  wheelOk: got.wheel != null && got.wheel.dy > 0,
+  keyOk: got.key?.key === "F13"
+}, null, 2));
+
+await evaluate("window.__rcpHandlers?.forEach(([t, f]) => window.removeEventListener(t, f, true)); delete window.__rcpHandlers; delete window.__rcpProbe; 'cleaned'");
+ws.close();

--- a/tests/mirror.test.mjs
+++ b/tests/mirror.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * BrowserMirror 单测：只桩掉 _command，验证对外行为——坐标换算、输入参数、
+ * 贴合/还原的 CDP 调用序列。不需要真浏览器。
+ *
+ *   node --test tests/
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { BrowserMirror, normalizeSources } from "../lib/index.js";
+
+/** 造一只不连 CDP 的 mirror，记录所有下发的命令。 */
+function stubMirror(viewport = { width: 1000, height: 800 }) {
+  const mirror = new BrowserMirror({ name: "test", port: 1, match: /x/ });
+  const calls = [];
+  mirror._command = (method, params) => {
+    calls.push({ method, params });
+    return Promise.resolve({ result: {} });
+  };
+  mirror.state.viewport = viewport;
+  return { mirror, calls };
+}
+
+test("鼠标坐标按视口反归一化，越界被夹住", () => {
+  const { mirror, calls } = stubMirror();
+  mirror.dispatchInput([
+    { kind: "mouse", type: "mouseMoved", nx: 0.25, ny: 0.5 },
+    { kind: "mouse", type: "mousePressed", nx: 1.4, ny: -0.3, button: "left", buttons: 1, clickCount: 2 }
+  ]);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(
+    { x: calls[0].params.x, y: calls[0].params.y },
+    { x: 250, y: 400 }
+  );
+  assert.deepEqual(
+    { x: calls[1].params.x, y: calls[1].params.y, clickCount: calls[1].params.clickCount },
+    { x: 1000, y: 0, clickCount: 2 }
+  );
+});
+
+test("滚轮增量按视口尺寸放大", () => {
+  const { mirror, calls } = stubMirror();
+  mirror.dispatchInput([{ kind: "mouse", type: "mouseWheel", nx: 0.5, ny: 0.5, ndx: 0.1, ndy: -0.25 }]);
+  assert.equal(calls[0].params.deltaX, 100);
+  assert.equal(calls[0].params.deltaY, -200);
+  assert.equal(calls[0].params.button, "none");
+});
+
+test("可打印字符带 text，功能键不带", () => {
+  const { mirror, calls } = stubMirror();
+  mirror.dispatchInput([
+    { kind: "key", type: "keyDown", key: "a", code: "KeyA", keyCode: 65, text: "a" },
+    { kind: "key", type: "rawKeyDown", key: "Enter", code: "Enter", keyCode: 13 }
+  ]);
+  assert.equal(calls[0].params.text, "a");
+  assert.equal(calls[0].params.windowsVirtualKeyCode, 65);
+  assert.equal(calls[1].params.text, undefined);
+  assert.equal(calls[1].params.windowsVirtualKeyCode, 13);
+});
+
+test("中文/粘贴走 insertText", () => {
+  const { mirror, calls } = stubMirror();
+  mirror.dispatchInput([{ kind: "text", text: "你好" }]);
+  assert.equal(calls[0].method, "Input.insertText");
+  assert.equal(calls[0].params.text, "你好");
+});
+
+test("非法事件被忽略，不下发命令", () => {
+  const { mirror, calls } = stubMirror();
+  const sent = mirror.dispatchInput([null, { kind: "nope" }, { kind: "text", text: "" }]);
+  assert.equal(sent, 0);
+  assert.equal(calls.length, 0);
+});
+
+test("贴合请求抖动小于 12px 时不重设", async () => {
+  const { mirror, calls } = stubMirror();
+  mirror.requestFit(900, 700, 1.5);
+  await mirror._applyFit();
+  const first = calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length;
+  mirror.requestFit(905, 703, 1.5);
+  await mirror._applyFit();
+  assert.equal(calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length, first);
+  mirror.requestFit(1200, 700, 1.5);
+  await mirror._applyFit();
+  assert.equal(calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length, first + 1);
+});
+
+test("取消贴合先用 0 宽高接管覆盖再 clear（否则清不掉别的会话留下的覆盖）", async () => {
+  const { mirror, calls } = stubMirror();
+  mirror.requestFit(900, 700, 1.5);
+  await mirror._applyFit();
+  assert.equal(mirror.state.fitted, true);
+  calls.length = 0;
+  mirror.requestFit(0, 0, 1);
+  await mirror._applyFit();
+  assert.deepEqual(calls.map((c) => c.method), [
+    "Emulation.setDeviceMetricsOverride",
+    "Emulation.clearDeviceMetricsOverride"
+  ]);
+  assert.deepEqual(calls[0].params, { width: 0, height: 0, deviceScaleFactor: 0, mobile: false });
+  assert.equal(mirror.state.fitted, false);
+});
+
+test("新会话在无贴合需求时补发一次还原，且只发一次", async () => {
+  const { mirror, calls } = stubMirror();
+  await mirror._applyFit();
+  assert.equal(calls.length, 2);
+  await mirror._applyFit();
+  assert.equal(calls.length, 2);
+});
+
+test("screencast 帧更新视口尺寸并广播给订阅者", () => {
+  const { mirror } = stubMirror({ width: 0, height: 0 });
+  const got = [];
+  mirror.subscribe((buf) => got.push(buf));
+  mirror._onEvent({
+    method: "Page.screencastFrame",
+    params: { data: Buffer.from("hello").toString("base64"), sessionId: 7, metadata: { deviceWidth: 640, deviceHeight: 480 } }
+  });
+  assert.deepEqual(mirror.state.viewport, { width: 640, height: 480 });
+  assert.equal(mirror.state.frameMode, "screencast");
+  assert.equal(got.length, 1);
+  assert.equal(got[0].toString(), "hello");
+});
+
+test("退订后不再收到帧", () => {
+  const { mirror } = stubMirror();
+  const got = [];
+  const off = mirror.subscribe((buf) => got.push(buf));
+  off();
+  mirror._onEvent({ method: "Page.screencastFrame", params: { data: Buffer.from("x").toString("base64"), sessionId: 1, metadata: {} } });
+  assert.equal(got.length, 0);
+});
+
+test("normalizeSources：patch 只写差异，userDataDir/homeUrl 从内置默认补", () => {
+  const list = normalizeSources([{ name: "boss", port: 53470, match: "zhipin\\.com" }]);
+  assert.equal(list[0].name, "boss");
+  assert.equal(list[0].port, 53470);
+  assert.equal(list[0].match, "zhipin\\.com");
+  assert.ok(list[0].userDataDir && list[0].userDataDir.includes(".boss-cli"));
+  assert.equal(list[0].homeUrl, "https://www.zhipin.com/web/chat/index");
+});
+
+test("normalizeSources：显式配置覆盖内置默认", () => {
+  const list = normalizeSources([{ name: "boss", userDataDir: "/custom/dir", homeUrl: "about:blank" }]);
+  assert.equal(list[0].userDataDir, "/custom/dir");
+  assert.equal(list[0].homeUrl, "about:blank");
+});
+
+test("normalizeSources：无配置用内置默认；未知源原样保留", () => {
+  const defs = normalizeSources(undefined);
+  assert.equal(defs.length, 1);
+  assert.equal(defs[0].name, "boss");
+  assert.ok(defs[0].userDataDir.includes(".boss-cli"));
+  const custom = normalizeSources([{ name: "liepin", port: 53471 }]);
+  assert.equal(custom[0].userDataDir, undefined);
+  assert.equal(custom[0].homeUrl, undefined);
+});


### PR DESCRIPTION
## 为什么

右侧面板原本是只读糊图，且会被 BOSS 反爬模块反复杀掉浏览器 —— 表现为面板崩溃、频繁要求重新登录。这个 PR 把它做成可直接操作的 dock 浏览器，并修掉崩溃根因。

## 改了什么

- **形态**：面板打开时给 `#root` 加 `margin-right` 让出宽度（layout-push），聊天不再被遮挡；视觉全量走 `--dsw-*` token，与 DSH 内置列一致；宽度记忆到 localStorage。
- **固定视口**：页面视口固定 958×1149（BOSS 页面在该尺寸渲染最完整），面板拖宽只影响显示缩放，不再跟随面板尺寸重设贴合。
- **反爬规避**：连接序列去掉 `Runtime.enable` —— BOSS 反爬把它当调试器挂载信号会主动杀浏览器（实测开启 0/4 存活，关闭 4/4 全活）。这是此前反复要求重新登录的诱因。
- **自愈与可用性**：盯梢时浏览器掉线自动重新拉起（10s 冷却）；启动按钮修复（patch 源缺 `userDataDir` 导致从未可用，改为按源与内置默认合并 `normalizeSources`）；浏览器未运行时不再挂误导性的 `cdp not connected`；启动超时 15s 自动复位。

## 测试

`npm test` → **13/13 通过**（新增 `normalizeSources` 等单测）。

## 文档

- `dsh/README.md` 同步新形态
- `dsh/panel-ux-redesign.md` 记录改造过程与崩溃根因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
