### PR TITLE
fix(dsh): 面板按下鼠标时补 force，让页面拿到规范要求的 pressure 0.5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -686,6 +686,10 @@ export class BrowserMirror {
           params.deltaX = clampNum(ev.ndx, 0, -10, 10) * vw;
           params.deltaY = clampNum(ev.ndy, 0, -10, 10) * vh;
         }
+        // `force` 决定页面拿到的 PointerEvent.pressure。不传时 CDP 默认 0，
+        // 而真实鼠标按住时规范值是 0.5——实测面板按下全是 0、真手全是 0.5，
+        // 是面板与真实输入之间唯一一处干净的结构性差异（#22）。
+        if (params.buttons > 0) params.force = 0.5;
         this._command("Input.dispatchMouseEvent", params);
         sent += 1;
         continue;

--- a/tests/mirror.test.mjs
+++ b/tests/mirror.test.mjs
@@ -37,6 +37,20 @@ test("鼠标坐标按视口反归一化，越界被夹住", () => {
   );
 });
 
+test("按住键时带 force，未按住不带——决定页面拿到的 PointerEvent.pressure", () => {
+  const { mirror, calls } = stubMirror();
+  mirror.dispatchInput([
+    { kind: "mouse", type: "mouseMoved", nx: 0.5, ny: 0.5, buttons: 0 },
+    { kind: "mouse", type: "mousePressed", nx: 0.5, ny: 0.5, button: "left", buttons: 1, clickCount: 1 },
+    { kind: "mouse", type: "mouseMoved", nx: 0.6, ny: 0.5, buttons: 1 },
+    { kind: "mouse", type: "mouseReleased", nx: 0.6, ny: 0.5, button: "left", buttons: 0, clickCount: 1 }
+  ]);
+  assert.equal(calls[0].params.force, undefined);
+  assert.equal(calls[1].params.force, 0.5);
+  assert.equal(calls[2].params.force, 0.5);
+  assert.equal(calls[3].params.force, undefined);
+});
+
 test("滚轮增量按视口尺寸放大", () => {
   const { mirror, calls } = stubMirror();
   mirror.dispatchInput([{ kind: "mouse", type: "mouseWheel", nx: 0.5, ny: 0.5, ndx: 0.1, ndy: -0.25 }]);


### PR DESCRIPTION
解 [#22](https://github.com/Viy1204/recruiting-copilot/issues/22)，属于地图 [#20](https://github.com/Viy1204/recruiting-copilot/issues/20)。

## 为什么

面板派发的 `PointerEvent` 里 `pressure` **恒为 0**。而 W3C Pointer Events 规定：不支持压感的设备（普通鼠标）**按下时必须是 0.5**，未按下才是 0。

页面因此看到的是「一个按着键却没有压力的指针」——一处**规范级的自相矛盾**，比 UA 里带不带 `Headless` 更容易被规则命中。

根因：`Input.dispatchMouseEvent` 的 `force` 参数不传时 CDP 默认给 `0`。

## 实测依据

同一个本地测试页、同一只手，只差输入通道这一个变量，共 6 组样本：

| | pointerdown 的 `pressure` |
|---|---|
| 真实 Chrome 窗口 | **0.5** |
| DSH 面板 | **0** |

往同一个页面分别派发不带 `force` 和带 `force: 0.5` 的 `mousePressed`，页面记录到 `[{pressure:0},{pressure:0.5}]` —— 一个参数直接决定。

**同一轮测量还排除了三条原本的怀疑**：

- 轨迹稀疏 —— 不成立。真手与面板的事件间隔中位数都是 16.6ms（一帧 @60Hz），面板的点间距 p95 反而比真手更小。
- `movementX/Y` 失真 —— 不成立，99% 与实际位移吻合。
- `isTrusted` 异常 —— 不成立，全为 true。

所以这个 PR **只改这一处**，没有动轨迹管线。

## 改动

`lib/index.js` 一行 + 三行注释，加一条测试（按住时带 `force`、未按住不带）。

## 验证

- `node --test "tests/*.test.mjs"` → **27/27**（新增 1 条）
- `node --check client.js && node --check lib/index.js` → 通过

## 不在本 PR 里的

原型测试页、本地服务与 6 组原始上报数据留在一次性分支 [`prototype/mouse-pressure`](https://github.com/Viy1204/recruiting-copilot/tree/prototype/mouse-pressure)，不进 master。

全程本地页面，没有访问任何招聘平台。

🤖 Generated with [Claude Code](https://claude.com/claude-code)