### PR TITLE
fix(dsh): 视口一律以页面回读为准，修面板点击整体偏移

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,8 @@ const PROBE_TIMEOUT_MS = 900;
 const COMMAND_TIMEOUT_MS = 6000;
 /** screencast 静默超过这个时长就回落到主动截图（窗口最小化/被遮挡时会静默）。 */
 const SCREENCAST_STALL_MS = 2500;
+/** 回读页面 CSS 视口的节流间隔：坐标换算的分母，贴合或缩放变化后要尽快跟上。 */
+const VIEWPORT_REFRESH_MS = 2000;
 /** 拉起浏览器后探针超过这个时长仍未就绪，判定启动失败（复位 launching）。 */
 const LAUNCH_TIMEOUT_MS = 15000;
 
@@ -355,10 +357,10 @@ export class BrowserMirror {
 
   _onEvent(msg) {
     if (msg.method === "Page.screencastFrame") {
-      const meta = msg.params?.metadata ?? {};
-      const width = Math.round(Number(meta.deviceWidth) || 0);
-      const height = Math.round(Number(meta.deviceHeight) || 0);
-      if (width > 0 && height > 0) this.state.viewport = { width, height };
+      // 不用 metadata.deviceWidth/Height 当视口：它描述的是被抓取的**画面**尺寸，
+      // 不是页面的 CSS 视口。两者在页面缩放不等于 100% 时会差一个 zoom 因子，
+      // 而 `_toPageXY` 拿视口当分母——差多少，点击就偏多少。视口一律以页面
+      // 自己报的 innerWidth/innerHeight 为准（见 `_refreshViewport`）。
       this._lastScreencastAt = Date.now();
       this.state.frameMode = "screencast";
       if (msg.params?.sessionId !== undefined) {
@@ -580,7 +582,12 @@ export class BrowserMirror {
     this._appliedFit = want;
     this._clearedOnce = false;
     this.state.fitted = true;
-    this.state.viewport = { width: want.width, height: want.height };
+    // 不能假定 `innerWidth === want.width`：Chrome 的**每源页面缩放**会叠在
+    // `setDeviceMetricsOverride` 之上，实测 zhipin.com 存着 90% 缩放时，覆盖
+    // 958×1149 得到的 CSS 视口是 1064×1276（= 958/0.9）。假定下去分母小 10%，
+    // 点击就落在光标左上方，离原点越远偏越多。强制立刻回读一次真实视口。
+    this._lastViewportAt = 0;
+    await this._refreshViewport();
   }
 
   /**
@@ -606,9 +613,18 @@ export class BrowserMirror {
     }
   }
 
-  /** 页面 CSS 视口（贴合模式下即面板尺寸；否则读真实窗口）。 */
+  /**
+   * 页面 CSS 视口——`_toPageXY` 的分母，坐标准不准全看它。
+   *
+   * 唯一可信的来源是页面自己报的 `innerWidth/innerHeight`：贴合的目标尺寸会被页面缩放
+   * 改写，screencast 的 metadata 说的又是画面尺寸而非 CSS 视口，两个都不能拿来当分母。
+   * 原先这里在 screencast 模式下直接返回，于是贴合写进去的错值一直没机会被纠正
+   * （poll 模式反而是对的，因为每轮都会走到这里）。现在不分模式一律回读，按 2s 节流。
+   */
   async _refreshViewport() {
-    if (this.state.viewport.width > 0 && this.state.frameMode === "screencast") return;
+    const now = Date.now();
+    if (now - (this._lastViewportAt ?? 0) < VIEWPORT_REFRESH_MS) return;
+    this._lastViewportAt = now;
     const msg = await this._command("Runtime.evaluate", {
       expression: "JSON.stringify({w:innerWidth,h:innerHeight})",
       returnByValue: true

--- a/tests/mirror.test.mjs
+++ b/tests/mirror.test.mjs
@@ -122,15 +122,18 @@ test("新会话在无贴合需求时补发一次还原，且只发一次", async
   assert.equal(calls.length, 2);
 });
 
-test("screencast 帧更新视口尺寸并广播给订阅者", () => {
-  const { mirror } = stubMirror({ width: 0, height: 0 });
+test("screencast 帧广播给订阅者，但不拿 metadata 当视口", () => {
+  // metadata.deviceWidth/Height 说的是被抓取的画面尺寸，不是页面 CSS 视口。
+  // 页面缩放不等于 100% 时两者差一个 zoom 因子，而视口是坐标换算的分母——
+  // 让 metadata 写它，点击就会整体偏移。
+  const { mirror } = stubMirror({ width: 1064, height: 1276 });
   const got = [];
   mirror.subscribe((buf) => got.push(buf));
   mirror._onEvent({
     method: "Page.screencastFrame",
     params: { data: Buffer.from("hello").toString("base64"), sessionId: 7, metadata: { deviceWidth: 640, deviceHeight: 480 } }
   });
-  assert.deepEqual(mirror.state.viewport, { width: 640, height: 480 });
+  assert.deepEqual(mirror.state.viewport, { width: 1064, height: 1276 });
   assert.equal(mirror.state.frameMode, "screencast");
   assert.equal(got.length, 1);
   assert.equal(got[0].toString(), "hello");
@@ -151,8 +154,43 @@ test("贴合不把 window.screen 一起盖掉（不传 screenWidth/screenHeight�
   await mirror._applyFit();
   const fit = calls.find((c) => c.method === "Emulation.setDeviceMetricsOverride");
   assert.deepEqual(fit.params, { width: 958, height: 1149, deviceScaleFactor: 1.5, mobile: false });
-  assert.equal(mirror.state.viewport.width, 958);
-  assert.equal(mirror.state.viewport.height, 1149);
+  assert.equal(mirror.state.fitted, true);
+});
+
+test("贴合后回读真实视口，而不是假定等于覆盖尺寸", async () => {
+  // Chrome 的每源页面缩放叠在 setDeviceMetricsOverride 之上：实测 zhipin.com 存着
+  // 90% 缩放时，覆盖 958×1149 得到的 CSS 视口是 1064×1276。假定下去分母小 10%，
+  // 点击会落在光标左上方，离原点越远偏越多。
+  const { mirror, calls } = stubMirror({ width: 0, height: 0 });
+  mirror._command = (method, params) => {
+    calls.push({ method, params });
+    if (method === "Runtime.evaluate") {
+      return Promise.resolve({ result: { result: { value: JSON.stringify({ w: 1064, h: 1276 }) } } });
+    }
+    return Promise.resolve({ result: {} });
+  };
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+  assert.deepEqual(mirror.state.viewport, { width: 1064, height: 1276 });
+
+  // 分母用回读值，坐标才对得上：面板最右下角应映射到 1064×1276，而不是 958×1149。
+  calls.length = 0;
+  mirror.dispatchInput([{ kind: "mouse", type: "mousePressed", nx: 1, ny: 1, button: "left", buttons: 1 }]);
+  const click = calls.find((c) => c.method === "Input.dispatchMouseEvent");
+  assert.equal(click.params.x, 1064);
+  assert.equal(click.params.y, 1276);
+});
+
+test("screencast 模式下视口依然会被回读纠正", async () => {
+  const { mirror } = stubMirror({ width: 958, height: 1149 });
+  mirror.state.frameMode = "screencast";
+  mirror._lastViewportAt = 0;
+  mirror._command = (method) =>
+    method === "Runtime.evaluate"
+      ? Promise.resolve({ result: { result: { value: JSON.stringify({ w: 1064, h: 1276 }) } } })
+      : Promise.resolve({ result: {} });
+  await mirror._refreshViewport();
+  assert.deepEqual(mirror.state.viewport, { width: 1064, height: 1276 });
 });
 
 test("无头下截图兜底不退到 fromSurface:false（那是 headful-only，会拿到废图）", async () => {


### PR DESCRIPTION
解 [#28](https://github.com/Viy1204/recruiting-copilot/issues/28)，属于地图 [#20](https://github.com/Viy1204/recruiting-copilot/issues/20)。

## 症状

面板里「指针和按钮对不上」——点击落在光标左上方，离原点越远偏得越多。

## 根因：坐标分母错了

`_toPageXY` 用 `state.viewport` 把归一化坐标还原成页面 CSS 坐标。而视口有两处在**假定**，两处都会错：

1. **`_applyFit` 直接把覆盖尺寸当视口。** Chrome 的**每源页面缩放**叠在 `setDeviceMetricsOverride` 之上——实测 `zhipin.com` 在这个 profile 里存着 90% 缩放，覆盖 958×1149 得到的 CSS 视口是 **1064×1276**（= 958/0.9）。
2. **`Page.screencastFrame` 的 `metadata.deviceWidth/Height` 被当成视口。** 实测那是**设备像素**：页面 CSS 1537×894 时 metadata 报 **1384×805**，正好差一个 `dpr` 0.9。

而 `_refreshViewport` 又在 screencast 模式下直接 `return`，错值一直没机会被纠正。

> poll 模式反而是对的（每轮都会回读）——这也是排查时一度被带偏的原因：先看到 poll 下的正确值，误判成帧率问题。

## 真机验证

同一只浏览器上并挂两个 host，一个打补丁一个不打：

| | host 记的 viewport | 页面真值 |
|---|---|---|
| **打过补丁** | **1537×894** ✅ | 1537×894 |
| 未打补丁 | 1384×805 ❌ | 1537×894 |

## 改动

视口只认页面自己报的 `innerWidth/innerHeight`：

- `_applyFit` 后强制立刻回读，不再假定
- `_refreshViewport` 去掉 screencast 模式的早退，改为按 2s 节流、不分模式
- `Page.screencastFrame` 不再写视口

## 验证

- `node --test "tests/*.test.mjs"` → **29/29**（新增 2 条：贴合后回读、screencast 下仍会纠正；改写 2 条原本锁定旧行为的用例）
- `node --check client.js && node --check lib/index.js` → 通过

## 顺带发现（未在本 PR 处理）

`_appliedFit` 是本地缓存，覆盖被第三方清掉后不会重发，host 会「以为自己贴合了」而实际没有。本 PR 的回读能挡住坐标层面的后果，但 `state.fitted` 仍会说谎。已记在 #28。

🤖 Generated with [Claude Code](https://claude.com/claude-code)