### PR TITLE
feat(dsh): 面板加有头/无头切换按钮，切换前先看有没有 CLI 在用

### DIFF
--- a/client.js
+++ b/client.js
@@ -71,6 +71,8 @@ window.__ModuleLoader__.load({
 			".rcp-page[data-active='true']{color:var(--dsw-alias-label-primary,#eee);border-color:var(--dsw-alias-border-l2,#3a3a42);background:var(--dsw-alias-bg-module-platform,#26262b)}",
 			".rcp-x{opacity:.45;padding:0 3px;border-radius:4px;cursor:pointer}",
 			".rcp-x:hover{opacity:1;background:var(--dsw-alias-interactive-bg-hover,rgba(255,255,255,.08))}",
+			".rcp-busy{color:var(--dsw-alias-state-warning-primary,#e0a458)}",
+			".rcp-notice{padding:6px 10px;font-size:12px;line-height:1.5;color:#f0d8a8;background:#3a2f1c;border-bottom:1px solid #4d3f26;cursor:pointer}",
 			".rcp-body{flex:1;min-height:0;position:relative;background:var(--dsw-alias-bg-layer-3,#0b0b0d);overflow:hidden;outline:0}",
 			".rcp-body img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;display:block;user-select:none;-webkit-user-drag:none}",
 			".rcp-body[data-live='true']{cursor:default}",
@@ -171,6 +173,10 @@ window.__ModuleLoader__.load({
 		// ── 面板组件 ────────────────────────────────────────────────────
 		function BrowserPanel() {
 			const [state, setState] = react.useState(null);
+			/** 模式切换进行中（关掉重开要几秒，按钮期间禁用并显示进度）。 */
+			const [switching, setSwitching] = react.useState(false);
+			/** 一次性提示（切换被拒绝等），点掉即消失。 */
+			const [notice, setNotice] = react.useState(null);
 			const [activeSource, setActiveSource] = react.useState("boss");
 			const [collapsed, setCollapsed] = react.useState(false);
 			const [mode, setMode] = react.useState("side");
@@ -447,6 +453,24 @@ window.__ModuleLoader__.load({
 				btn("＋", "新标签页", () => control("new-tab"), { disabled: !connected }),
 				btn(interactive ? "🖱" : "🔒", interactive ? "可操作（点画面直接操作浏览器）" : "只读（点击不再传给浏览器）", () => setInteractive((v) => !v), { "data-on": String(interactive) }),
 				btn("贴合", "贴合：页面视口固定 958×1149（截得全）；关掉则显示浏览器真实窗口画面", () => setFit((v) => !v), { "data-on": String(fit) }),
+				// 有头/无头切换：Chrome 起来后不能热切，必然是关掉重开，所以有 CLI 命令
+				// 在操作同一只浏览器时直接禁用（host 侧也会再拒一次，见 setMode）。
+				btn(
+					switching ? "…" : active?.headless === false ? "🖥" : "🕶",
+					active?.busy
+						? `「${active.busy.command}」正在操作这只浏览器，切换会打断它——等它结束再切`
+						: active?.headless === false
+							? "当前有头（真窗口，会抢焦点）。点一下切回无头"
+							: "当前无头（不抢焦点，画面只在这个面板里）。点一下开出真窗口，用于人工验证",
+					async () => {
+						if (switching) return;
+						setSwitching(true);
+						const res = await control("set-mode", { hidden: active?.headless === false });
+						setSwitching(false);
+						if (!res?.ok && res?.error) setNotice(res.error);
+					},
+					{ disabled: !connected || !!active?.busy || switching, "data-on": String(active?.headless === false) }
+				),
 				btn(mode === "max" ? "⇲" : "⇱", mode === "max" ? "还原为右侧面板" : "放大到整屏", () => setMode((m) => (m === "max" ? "side" : "max"))),
 				btn("—", "折叠", () => setCollapsed(true))
 			);
@@ -523,6 +547,11 @@ window.__ModuleLoader__.load({
 			const foot = h("div", { className: "rcp-foot" },
 				h("span", null, connected ? `${viewport.width}×${viewport.height}` : "—"),
 				h("span", null, active?.frameMode === "screencast" ? "推流" : active?.frameMode === "poll" ? "轮询" : "空闲"),
+				h("span", { title: "浏览器当前是无头还是有头窗口" }, active?.headless === false ? "有头" : active?.headless === true ? "无头" : "—"),
+				active?.busy
+					? h("span", { className: "rcp-busy", title: `pid ${active.busy.pid}，已跑 ${Math.round(active.busy.ageMs / 1000)}s` },
+						`⏳ ${active.busy.command}`)
+					: null,
 				h("span", { className: "rcp-spacer" }),
 				h("span", { className: "rcp-x", title: "把真实浏览器窗口唤到前台", onClick: () => control("activate") }, "唤起窗口")
 			);
@@ -542,6 +571,9 @@ window.__ModuleLoader__.load({
 					})
 					: null,
 				head,
+				notice
+					? h("div", { className: "rcp-notice", onClick: () => setNotice(null), title: "点掉这条提示" }, notice)
+					: null,
 				pages.length > 0 || sources.length > 1 ? tabs : null,
 				body,
 				foot

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -138,6 +138,60 @@ const VIEWPORT_REFRESH_MS = 2000;
 const LAUNCH_TIMEOUT_MS = 15000;
 
 /**
+ * CLI 占用锁的共享目录。三方（本插件 / boss-cli / liepin-cli）共用同一约定，
+ * 与 `RECRUIT_BROWSER_HIDDEN` 同样的做法：CLI 命令开始时写 `<source>.busy.json`，
+ * 结束时删掉；面板读它来判断「此刻有没有命令正在操作同一只浏览器」。
+ *
+ * 进程被 kill 会留下僵尸锁，所以**光有文件不算数**——必须 pid 还活着。
+ * 这样既不需要 CLI 保证一定能跑完清理逻辑，也不会把面板永久锁死。
+ */
+const BUSY_DIR = path.join(homedir(), ".recruit-browser");
+
+/** 锁文件里的 pid 是否还活着。signal 0 只做权限/存在性检查，不真的发信号。 */
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM = 进程存在但不属于本用户，仍然算活着
+    return error?.code === "EPERM";
+  }
+}
+
+/**
+ * 读某个源的 CLI 占用锁。返回 null 表示空闲。
+ * 锁存在但 pid 已死时顺手删掉——僵尸锁不该让面板一直拒绝切换。
+ */
+function readBusyLock(sourceName, now = Date.now()) {
+  const file = path.join(BUSY_DIR, `${sourceName}.busy.json`);
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let lock;
+  try {
+    lock = JSON.parse(raw);
+  } catch {
+    try { unlinkSync(file); } catch { /* 并发删除，忽略 */ }
+    return null;
+  }
+  if (!pidAlive(lock?.pid)) {
+    try { unlinkSync(file); } catch { /* 并发删除，忽略 */ }
+    return null;
+  }
+  const startedAt = Number(lock.startedAt) || now;
+  return {
+    command: typeof lock.command === "string" ? lock.command : "(未命名命令)",
+    pid: lock.pid,
+    startedAt,
+    ageMs: Math.max(0, now - startedAt)
+  };
+}
+
+/**
  * 合并 patch 配置与内置默认：patch 里的 source 只写差异（port/match），
  * userDataDir / homeUrl 等默认从 DEFAULT_SOURCES 补上；同名源不存在时
  * 原样保留（如未来的 liepin 源，仍由构造函数给兜底值）。
@@ -222,6 +276,8 @@ export class BrowserMirror {
       /** 当前是否用 Emulation 把页面视口贴合到了面板尺寸。 */
       fitted: false,
       frameMode: "idle",
+      /** 此刻是否有 CLI 命令在操作同一只浏览器（读共享锁，null = 空闲）。 */
+      busy: null,
       lastFrameAt: 0,
       seq: 0,
       error: null
@@ -231,6 +287,8 @@ export class BrowserMirror {
     this._pending = new Map();
     this._commandSeq = 0;
     this._targetOverride = null;
+    /** setMode 重启后要回到的页面（只用一次，见 tick）。 */
+    this._pendingHomeUrl = null;
     this._frame = null;
     this._subscribers = new Set();
     /** 当前这一路 MJPEG 的关闭函数（一个源同时只保留一路，见 takeoverStream）。 */
@@ -653,8 +711,15 @@ export class BrowserMirror {
         }
         return;
       }
+      // 切换模式重启后回到切换前那一页（setMode 记下的），只做一次。
+      if (this._pendingHomeUrl && this.state.connected) {
+        const url = this._pendingHomeUrl;
+        this._pendingHomeUrl = null;
+        await this.navigate(url);
+      }
       await this._applyFit();
       const now = Date.now();
+      this.state.busy = readBusyLock(this.name, now);
       const stalled = now - this._lastScreencastAt > SCREENCAST_STALL_MS;
       if (stalled && this._subscribers.size > 0 && now - this._lastPollAt > 700) {
         this._lastPollAt = now;
@@ -795,7 +860,7 @@ export class BrowserMirror {
    * 拉起浏览器：与 boss-cli 同一 user-data-dir 和调试端口，因此后续 boss 命令
    * 会直连这只实例（同一登录态），不会另开一只。
    */
-  async launch() {
+  async launch(hidden = null) {
     if (this.state.connected) return { ok: true, already: true };
     if (await this._probe()) return { ok: true, already: true };
     if (!this.userDataDir) return { ok: false, error: `源「${this.name}」未配置 userDataDir，无法拉起浏览器` };
@@ -803,7 +868,7 @@ export class BrowserMirror {
     if (!exe) return { ok: false, error: "未找到本机 Chrome/Edge：请设置 CHROME_PATH" };
     const args = [
       ...CHROME_LAUNCH_ARGS,
-      ...(hiddenModeEnabled() ? HIDDEN_LAUNCH_ARGS : HEADFUL_LAUNCH_ARGS),
+      ...((hidden ?? hiddenModeEnabled()) ? HIDDEN_LAUNCH_ARGS : HEADFUL_LAUNCH_ARGS),
       `--user-data-dir=${this.userDataDir}`,
       `--remote-debugging-port=${this.port}`,
       this.homeUrl
@@ -818,6 +883,69 @@ export class BrowserMirror {
     } catch (error) {
       return { ok: false, error: String(error?.message ?? error) };
     }
+  }
+
+  /** 关掉整只浏览器（浏览器级 CDP 会话发 Browser.close；页面级会话没有这个域）。 */
+  async _closeBrowser() {
+    const version = await this._probe();
+    if (!version) return true; // 已经没了
+    return await new Promise((resolve) => {
+      let ws;
+      const done = (ok) => {
+        try { ws?.close(); } catch { /* ignore */ }
+        resolve(ok);
+      };
+      const timer = setTimeout(() => done(false), COMMAND_TIMEOUT_MS);
+      try {
+        ws = new WebSocket(version.webSocketDebuggerUrl);
+        ws.addEventListener("open", () => ws.send(JSON.stringify({ id: 1, method: "Browser.close", params: {} })));
+        // Browser.close 之后连接会被关掉，收不到回执才是正常的
+        ws.addEventListener("close", () => { clearTimeout(timer); done(true); });
+        ws.addEventListener("error", () => { clearTimeout(timer); done(false); });
+      } catch {
+        clearTimeout(timer);
+        done(false);
+      }
+    });
+  }
+
+  /**
+   * 切换有头 / 无头。
+   *
+   * Chrome 起来之后不能热切模式，只能关掉重开，所以这个动作**必然**会打断这只浏览器上
+   * 正在进行的一切。因此：
+   *
+   * 1. 有 CLI 命令正在操作同一只浏览器时**直接拒绝**并说明是哪条、跑了多久（#23 定的锁）。
+   *    不排队等待——一条寻源命令可能跑几分钟，按钮点下去没反应比报错更糟。
+   * 2. 关掉之前记住当前 URL，起来之后导航回去，否则每次切换都要手动找回页面。
+   * 3. 登录态在 user-data-dir 里，关掉重启不会丢。
+   */
+  async setMode(hidden) {
+    const want = hidden === true;
+    const busy = readBusyLock(this.name);
+    if (busy) {
+      const secs = Math.round(busy.ageMs / 1000);
+      return {
+        ok: false,
+        busy,
+        error: `「${busy.command}」正在操作这只浏览器（已跑 ${secs}s，pid ${busy.pid}）。` +
+          `切换模式要关掉浏览器重开，会打断它。等它结束，或先停掉它再切。`
+      };
+    }
+    if (this.state.connected && this.state.headless === want) {
+      return { ok: true, already: true, headless: want };
+    }
+    const back = this.state.targetUrl && this.state.targetUrl !== "about:blank" ? this.state.targetUrl : this.homeUrl;
+    const closed = await this._closeBrowser();
+    if (!closed) return { ok: false, error: "关闭浏览器失败：可能有别的程序占着调试端口" };
+    this._dropConnection();
+    this._appliedFit = null;
+    // 端口释放要一点时间，没等到就 launch 会撞上「已存在实例」的探测分支
+    for (let i = 0; i < 20 && (await this._probe()); i++) await new Promise((r) => setTimeout(r, 250));
+    const launched = await this.launch(want);
+    if (!launched.ok) return launched;
+    this._pendingHomeUrl = back;
+    return { ok: true, headless: want, restoring: back };
   }
 
   dispose() {
@@ -1006,6 +1134,8 @@ function makeRouteHandler(mirrors) {
       } else if (action === "unfit") {
         mirror.requestFit(0, 0, 1);
         result = { ok: true };
+      } else if (action === "set-mode") {
+        result = await mirror.setMode(body.hidden === true);
       } else if (action === "watch") {
         mirror.setWatch(body.on === true);
         result = { ok: true };
@@ -1065,4 +1195,4 @@ export function apply(ctx, rawConfig = {}) {
   }, "recruiting-copilot: browser mirror");
 }
 
-export { NAME, inject, normalizeSources, hiddenModeEnabled, readHeadless, streamMjpeg };
+export { NAME, inject, normalizeSources, hiddenModeEnabled, readHeadless, streamMjpeg, readBusyLock, BUSY_DIR };

--- a/tests/mirror.test.mjs
+++ b/tests/mirror.test.mjs
@@ -6,7 +6,9 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { BrowserMirror, normalizeSources, hiddenModeEnabled, readHeadless, streamMjpeg } from "../lib/index.js";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { BrowserMirror, normalizeSources, hiddenModeEnabled, readHeadless, streamMjpeg, readBusyLock, BUSY_DIR } from "../lib/index.js";
 
 /** 造一只不连 CDP 的 mirror，记录所有下发的命令。 */
 function stubMirror(viewport = { width: 1000, height: 800 }) {
@@ -401,4 +403,47 @@ test("dispose 时把在跑的 stream 一并收掉", () => {
   mirror.dispose();
   assert.equal(a.state.ended, true);
   assert.equal(mirror._subscribers.size, 0);
+});
+
+test("CLI 占用锁：pid 还活着才算数，僵尸锁自动清掉", () => {
+  const name = "__test_busy__";
+  const file = path.join(BUSY_DIR, `${name}.busy.json`);
+  mkdirSync(BUSY_DIR, { recursive: true });
+  try {
+    assert.equal(readBusyLock(name), null, "没有文件时应为空闲");
+
+    writeFileSync(file, JSON.stringify({ pid: process.pid, command: "boss search", startedAt: Date.now() - 3000 }));
+    const live = readBusyLock(name);
+    assert.equal(live.command, "boss search");
+    assert.ok(live.ageMs >= 3000);
+
+    // 几乎不可能存在的 pid：锁应被判为僵尸并删除
+    writeFileSync(file, JSON.stringify({ pid: 0x7ffffffe, command: "boss greet", startedAt: Date.now() }));
+    assert.equal(readBusyLock(name), null, "pid 已死时应视为空闲");
+    assert.equal(existsSync(file), false, "僵尸锁应被删掉");
+
+    writeFileSync(file, "{ 这不是 json");
+    assert.equal(readBusyLock(name), null, "坏文件应视为空闲");
+    assert.equal(existsSync(file), false, "坏文件应被删掉");
+  } finally {
+    try { unlinkSync(file); } catch { /* 已删 */ }
+  }
+});
+
+test("有 CLI 命令在跑时拒绝切换模式，并说清是哪条、跑了多久", async () => {
+  const { mirror } = stubMirror();
+  mirror.name = "__test_busy2__";
+  const file = path.join(BUSY_DIR, `${mirror.name}.busy.json`);
+  mkdirSync(BUSY_DIR, { recursive: true });
+  writeFileSync(file, JSON.stringify({ pid: process.pid, command: "boss search", startedAt: Date.now() - 12000 }));
+  try {
+    const res = await mirror.setMode(false);
+    assert.equal(res.ok, false);
+    assert.equal(res.busy.command, "boss search");
+    assert.match(res.error, /boss search/);
+    assert.match(res.error, /12s/);
+    assert.match(res.error, new RegExp(String(process.pid)));
+  } finally {
+    try { unlinkSync(file); } catch { /* ignore */ }
+  }
 });


### PR DESCRIPTION
解 [#23](https://github.com/Viy1204/recruiting-copilot/issues/23) 与 [#24](https://github.com/Viy1204/recruiting-copilot/issues/24)，属于地图 [#20](https://github.com/Viy1204/recruiting-copilot/issues/20)。

配套：[boss-cli#5](https://github.com/Viy1204/boss-cli/pull/5)、[liepin-cli#16](https://github.com/Viy1204/liepin-cli/pull/16)（写锁端）。

## #23：面板怎么知道有 CLI 在操作同一只浏览器

**选 sidecar 锁文件 + pid 存活校验。**

```
~/.recruit-browser/<source>.busy.json
{ "pid": 12345, "command": "boss search", "startedAt": 1787000000000 }
```

与 `RECRUIT_BROWSER_HIDDEN` 同级的三方共享约定。CLI 命令开始写、`finally` 里删。

**关键点：光有文件不算数，必须 pid 还活着。** 进程被 kill 会留下僵尸锁；读锁的一方（本插件）校验 `process.kill(pid, 0)`，死了就顺手删掉。这样 CLI 那边不需要保证清理逻辑一定跑到，面板也不会被永久锁死。

其余三个候选为什么没选：

- **数 CDP session**：面板自己也占一条，分不清谁是谁；liepin 侧行为未知。
- **进程探测**：交互模式下 `boss` 进程常驻，会永远误报「在跑」。
- **CLI 提供让出接口**：要改两个 CLI 的执行模型，代价远大于收益，而且 CLI 不在跑时没人应答。

## #24：切换按钮

- 按钮显示**当前实际模式**（🕶 无头 / 🖥 有头），读的是 `/json/version` 的 UA，不是本进程的意图
- **只切当前源那只**，不是两只一起——撞验证的只会是其中一个平台
- 关掉前**记住当前 URL**，起来后导航回去
- **有命令在跑时直接拒绝**，不排队：一条寻源命令可能跑几分钟，按钮点下去没反应比报错更糟。错误文案说清是哪条命令、跑了多久、pid 多少
- 状态栏补了当前模式与占用中的命令名；被拒绝时出一条可点掉的提示条
- 切换期间按钮显示 `…` 并禁用

登录态在 user-data-dir 里，关掉重启不会丢。

## 验证

- `node --test "tests/*.test.mjs"` → **31/31**（新增 2 条：僵尸锁自动清理、占用时拒绝切换且文案含命令名/时长/pid）
- `node --check client.js && node --check lib/index.js` → 通过

## 没做的

按钮的**真机联调**没做：BOSS 账号在写这个 PR 期间被风控临时限制（至 16:08），期间不宜再动那只浏览器。合并后需要 `dsh plugin update` + 重启 DSH 会话再实际点一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)