### PR TITLE
fix(dsh): 贴合状态以页面回读为准，别再「以为自己贴合了」

### DIFF
--- a/dsh/README.md
+++ b/dsh/README.md
@@ -81,6 +81,13 @@ RECRUIT_BROWSER_HIDDEN=false     # 三方共读：本插件 / boss-cli / liepin-
   （958×1149 这种竖屏、且 `availHeight === height` 没有任务栏），本身就是自动化指纹。
   实测不传时 `innerWidth`/`innerHeight` 依然精确等于目标值，面板效果一字不差，而真实
   screen（无头下由 `--screen-info` 给定）能透出来。
+  **贴合状态不能只信本地缓存**：覆盖会被第三方清掉（并挂的第二个 host、真窗口里改缩放、
+  导航重置、崩溃重连），而 `_appliedFit` 还记着「已应用」，早退分支命中就再也不重发，
+  于是 `state.fitted` 说谎、页面静默跑在非固定视口下。判据不能是「回读值 === 覆盖尺寸」——
+  页面缩放叠在覆盖之上，两者合法地不相等（958 + 90% = 1064）。做法是**记住贴合当时回读到的
+  视口当基准**，之后只看偏离（阈值 `FIT_DRIFT_PX`，要盖过滚动条那十几像素）。
+  **重发必须有上限**（`FIT_DRIFT_LIMIT`）：真抢不过第三方时，无限重发就是把页面按秒 resize，
+  那正是把账号弹到 403 的成因；超限就停手并把原因写进 `state.error`，等用户重按贴合或换连接。
 - **浏览器没起时**：面板里点「在这里启动浏览器」，host 用与 boss-cli 相同的
   user-data-dir（`~/.boss-cli/.cache/browser-data`）和调试端口拉起 Chrome，登录态
   通用；之后跑 boss 命令会 `probe` 到这只已存在的实例直接复用，不会另开一只。

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,6 +134,23 @@ const COMMAND_TIMEOUT_MS = 6000;
 const SCREENCAST_STALL_MS = 2500;
 /** 回读页面 CSS 视口的节流间隔：坐标换算的分母，贴合或缩放变化后要尽快跟上。 */
 const VIEWPORT_REFRESH_MS = 2000;
+/**
+ * 回读视口偏离贴合基准多少像素算「覆盖没了」。
+ *
+ * 判据不能是「回读值 === 覆盖尺寸」——页面缩放叠在覆盖之上，两者合法地不相等
+ * （958 覆盖 + 90% 缩放 = 1064，见 #28）。所以记住贴合当时回读到的值当基准，
+ * 之后只看有没有偏离。阈值要盖过滚动条出现/消失那十几像素，又要小于缩放换一档
+ * （最小 90%→100%，约 10%）与覆盖被清掉（通常几百像素）。
+ */
+const FIT_DRIFT_PX = 24;
+/**
+ * 连续这么多次重发都稳不住就停手。
+ *
+ * 无限重发会复刻引发账号被弹 403 的那个成因：反复 setDeviceMetricsOverride 让页面
+ * 秒级内反复 resize。真有第三方在抢覆盖（如并挂第二个 host）时，重发赢不了，
+ * 只能停下来把话说清楚。
+ */
+const FIT_DRIFT_LIMIT = 3;
 /** 拉起浏览器后探针超过这个时长仍未就绪，判定启动失败（复位 launching）。 */
 const LAUNCH_TIMEOUT_MS = 15000;
 
@@ -298,6 +315,13 @@ export class BrowserMirror {
     this._lastListAt = 0;
     this._fitRequest = null;
     this._appliedFit = null;
+    /** 贴合当时回读到的视口，用作「覆盖还在不在」的基准（null = 还没测到）。 */
+    this._fitBaseline = null;
+    /** 上次判定失真时观测到的视口：用来看重发到底有没有生效。 */
+    this._fitDriftAt = null;
+    this._fitDriftCount = 0;
+    /** 反复重发也稳不住后停手，等用户重按贴合或换连接才再试。 */
+    this._fitGaveUp = false;
     this._clearedOnce = false;
     this._launchingSince = 0;
     this._everConnected = false;
@@ -310,10 +334,24 @@ export class BrowserMirror {
     this._watch = on === true;
   }
 
+  /**
+   * 忘掉贴合缓存。
+   *
+   * 连接、抓取目标或浏览器进程换掉之后，之前那个覆盖不可能还在，缓存留着就会让
+   * `_applyFit` 的早退分支命中、不再重发（就是 #30 那个「以为自己贴合了」）。
+   */
+  _resetFitCache() {
+    this._appliedFit = null;
+    this._fitBaseline = null;
+    this._fitDriftAt = null;
+    this._fitDriftCount = 0;
+    this._fitGaveUp = false;
+  }
+
   /** 切换抓取目标（pageId 来自 state.pages[].id）。 */
   setTarget(pageId) {
     this._targetOverride = pageId || null;
-    this._appliedFit = null;
+    this._resetFitCache();
     this._dropConnection();
   }
 
@@ -449,7 +487,7 @@ export class BrowserMirror {
       // 浏览器没在跑不是错误：清掉上次连接受损留下的误导性报错（如
       // "cdp not connected"），空态文案自己会说明该启动浏览器。
       this.state.error = null;
-      this._appliedFit = null;
+      this._resetFitCache();
       this._dropConnection();
       return false;
     }
@@ -535,7 +573,7 @@ export class BrowserMirror {
       // 注意：不要发 Runtime.enable —— BOSS 反爬模块把它当调试器挂载信号，
       // 会主动杀掉整个浏览器（实测 0/4 存活）；不开它抓帧 4/4 全活。
       // Runtime.evaluate 等命令不需要 enable 也能用（镜像也不消费 Runtime 事件）。
-      this._appliedFit = null;
+      this._resetFitCache();
       this._clearedOnce = false;
       await this._applyFit();
       await this._startScreencast();
@@ -588,6 +626,9 @@ export class BrowserMirror {
   requestFit(width, height, deviceScaleFactor) {
     if (!(width > 0) || !(height > 0)) {
       this._fitRequest = null;
+      this._fitGaveUp = false;
+      this._fitDriftCount = 0;
+      this._fitDriftAt = null;
       return;
     }
     const next = {
@@ -601,6 +642,10 @@ export class BrowserMirror {
       return;
     }
     this._fitRequest = next;
+    // 用户改了尺寸就是「再试一次」，把停手状态放开。
+    this._fitGaveUp = false;
+    this._fitDriftCount = 0;
+    this._fitDriftAt = null;
   }
 
   async _applyFit() {
@@ -623,6 +668,8 @@ export class BrowserMirror {
     if (applied && applied.width === want.width && applied.height === want.height && applied.deviceScaleFactor === want.deviceScaleFactor) {
       return;
     }
+    // 抢不过第三方时停手，别用重发跟它对刷（见 FIT_DRIFT_LIMIT）。
+    if (this._fitGaveUp) return;
     // 不传 screenWidth/screenHeight：传了会把 window.screen 一起盖成视口尺寸（958x1149
     // 这种竖屏、且 availHeight === height 没有任务栏），本身就是自动化指纹。实测不传时
     // innerWidth/innerHeight 依然精确等于 want，面板要的视口固定效果不变，而真实
@@ -640,12 +687,64 @@ export class BrowserMirror {
     this._appliedFit = want;
     this._clearedOnce = false;
     this.state.fitted = true;
+    // 基准先作废：紧接着那次回读是用来建立新基准的，不能拿旧基准判它失真。
+    this._fitBaseline = null;
     // 不能假定 `innerWidth === want.width`：Chrome 的**每源页面缩放**会叠在
     // `setDeviceMetricsOverride` 之上，实测 zhipin.com 存着 90% 缩放时，覆盖
     // 958×1149 得到的 CSS 视口是 1064×1276（= 958/0.9）。假定下去分母小 10%，
     // 点击就落在光标左上方，离原点越远偏越多。强制立刻回读一次真实视口。
     this._lastViewportAt = 0;
     await this._refreshViewport();
+    // 回读到了才立基准；回读失败时留空，宁可这一轮不做失真判定，也不能拿 0×0
+    // 当基准——那会把之后任何正常回读都判成失真，变成无限重发。
+    const vp = this.state.viewport;
+    if (!(vp.width > 0 && vp.height > 0)) return;
+    // 重发后视口和失真时一模一样，说明这次覆盖压根没生效（对面清得比我们发得快，
+    // 或者覆盖被拒）。不能就这样立基准——基准立在「没贴合」的尺寸上，之后每次判定
+    // 都会通过，于是又退回 #30 那个 fitted 说谎的状态，只是这回还多了一次无效重发。
+    const drift = this._fitDriftAt;
+    if (drift && Math.abs(vp.width - drift.width) < FIT_DRIFT_PX && Math.abs(vp.height - drift.height) < FIT_DRIFT_PX) {
+      this.state.fitted = false;
+      // 缓存也要作废：留着 want 会让早退分支命中，而基准为空又让失真判定瘫掉，
+      // 结果卡在「没贴合、也不再重试、还谁都不报错」。
+      this._appliedFit = null;
+      this._countFitDrift();
+      return;
+    }
+    this._fitBaseline = { width: vp.width, height: vp.height };
+    this._fitDriftAt = null;
+  }
+
+  /** 记一次贴合没稳住；超过上限就停手。 */
+  _countFitDrift() {
+    this._fitDriftCount += 1;
+    if (this._fitDriftCount <= FIT_DRIFT_LIMIT) return;
+    this._fitGaveUp = true;
+    this.state.error =
+      `贴合反复被清掉（${this._fitDriftCount} 次），已停止重发：` +
+      "多半有第二个程序在操作同一只浏览器（别并挂第二个 host），也可能是真窗口里改了页面缩放。";
+  }
+
+  /**
+   * 覆盖还在不在：拿回读视口和贴合基准比。
+   *
+   * 偏离了说明覆盖被清掉（第三方接管、导航重置、崩溃重连）或页面缩放被改动，
+   * 两种情况都该重发。这里只作废缓存，重发交给 tick 里既有的 `_applyFit`，
+   * 免得判定路径上再多一条发命令的入口。
+   */
+  _checkFitDrift() {
+    const base = this._fitBaseline;
+    if (this._appliedFit === null || base === null) return;
+    const vp = this.state.viewport;
+    if (Math.abs(vp.width - base.width) < FIT_DRIFT_PX && Math.abs(vp.height - base.height) < FIT_DRIFT_PX) {
+      this._fitDriftCount = 0;
+      return;
+    }
+    this._appliedFit = null;
+    this._fitBaseline = null;
+    this._fitDriftAt = { width: vp.width, height: vp.height };
+    this.state.fitted = false;
+    this._countFitDrift();
   }
 
   /**
@@ -689,7 +788,10 @@ export class BrowserMirror {
     });
     try {
       const { w, h } = JSON.parse(msg?.result?.result?.value ?? "{}");
-      if (w > 0 && h > 0) this.state.viewport = { width: Math.round(w), height: Math.round(h) };
+      if (w > 0 && h > 0) {
+        this.state.viewport = { width: Math.round(w), height: Math.round(h) };
+        this._checkFitDrift();
+      }
     } catch { /* ignore */ }
   }
 
@@ -939,7 +1041,7 @@ export class BrowserMirror {
     const closed = await this._closeBrowser();
     if (!closed) return { ok: false, error: "关闭浏览器失败：可能有别的程序占着调试端口" };
     this._dropConnection();
-    this._appliedFit = null;
+    this._resetFitCache();
     // 端口释放要一点时间，没等到就 launch 会撞上「已存在实例」的探测分支
     for (let i = 0; i < 20 && (await this._probe()); i++) await new Promise((r) => setTimeout(r, 250));
     const launched = await this.launch(want);
@@ -957,7 +1059,7 @@ export class BrowserMirror {
       this._command("Emulation.setDeviceMetricsOverride", { width: 0, height: 0, deviceScaleFactor: 0, mobile: false });
       this._command("Emulation.clearDeviceMetricsOverride", {});
       this._command("Page.stopScreencast", {});
-      this._appliedFit = null;
+      this._resetFitCache();
       this.state.fitted = false;
     }
     this._dropConnection();

--- a/tests/mirror.test.mjs
+++ b/tests/mirror.test.mjs
@@ -195,6 +195,200 @@ test("screencast 模式下视口依然会被回读纠正", async () => {
   assert.deepEqual(mirror.state.viewport, { width: 1064, height: 1276 });
 });
 
+/**
+ * 造一只带「页面会响应覆盖」行为的 mirror：发 setDeviceMetricsOverride 后回读值就变成
+ * `覆盖尺寸 / 0.9`（模拟 zhipin.com 那个 90% 页面缩放，见 #28）。
+ *
+ * - `clearOverride()` 模拟第三方把覆盖清掉：回读值跳回真实窗口尺寸。
+ * - `honorOverride(false)` 模拟重发压根不生效（对面清得比我们发得快）。
+ * - `reread()` 绕过 2s 节流，好在一个测试里连着回读多轮。
+ */
+const WINDOW_VIEWPORT = { w: 1537, h: 894 };
+function fitDriftMirror() {
+  const { mirror, calls } = stubMirror({ width: 0, height: 0 });
+  let read = { ...WINDOW_VIEWPORT };
+  let honor = true;
+  mirror._command = (method, params) => {
+    calls.push({ method, params });
+    if (method === "Runtime.evaluate") {
+      return Promise.resolve({ result: { result: { value: JSON.stringify(read) } } });
+    }
+    if (method === "Emulation.setDeviceMetricsOverride" && honor && params.width > 0) {
+      read = { w: Math.round(params.width / 0.9), h: Math.round(params.height / 0.9) };
+    }
+    return Promise.resolve({ result: {} });
+  };
+  return {
+    mirror,
+    calls,
+    clearOverride: () => {
+      read = { ...WINDOW_VIEWPORT };
+    },
+    honorOverride: (on) => {
+      honor = on;
+    },
+    setViewport: (w, h) => {
+      read = { w, h };
+    },
+    reread: async () => {
+      mirror._lastViewportAt = 0;
+      await mirror._refreshViewport();
+    }
+  };
+}
+
+test("覆盖被第三方清掉后，fitted 不再说谎且下一轮会重发", async () => {
+  const { mirror, calls, clearOverride, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+  assert.equal(mirror.state.fitted, true);
+  // 基准是回读值（958/0.9），不是覆盖尺寸本身。
+  assert.deepEqual(mirror._fitBaseline, { width: 1064, height: 1277 });
+
+  // 第二个 host 清掉了覆盖：页面回到真实窗口尺寸。
+  clearOverride();
+  await reread();
+  assert.equal(mirror.state.fitted, false, "state.fitted 要跟着实际走，不能停在 true");
+
+  // 缓存已作废 → tick 里的 _applyFit 会真的再发一次覆盖。
+  calls.length = 0;
+  await mirror._applyFit();
+  const resent = calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride");
+  assert.equal(resent.length, 1);
+  assert.equal(resent[0].params.width, 958);
+  assert.equal(mirror.state.fitted, true);
+  // 计数要等下一轮验证过「覆盖真还在」才归零：重发当场归零的话，「每轮都被清」
+  // 这个正需要停手的场景会永远攒不到上限。
+  assert.equal(mirror._fitDriftCount, 1);
+  await reread();
+  assert.equal(mirror._fitDriftCount, 0);
+  assert.equal(mirror.state.fitted, true);
+});
+
+test("页面缩放让回读值合法地不等于覆盖尺寸，不算失真", async () => {
+  const { mirror, calls, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+
+  // 回读 1064×1277 ≠ 覆盖 958×1149（90% 缩放），但和基准一致 —— 不该重发。
+  calls.length = 0;
+  await reread();
+  await mirror._applyFit();
+  assert.equal(mirror.state.fitted, true);
+  assert.equal(calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length, 0);
+});
+
+test("滚动条那点尺寸变化不触发重发", async () => {
+  const { mirror, calls, setViewport, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+
+  calls.length = 0;
+  setViewport(1064 - 15, 1277);
+  await reread();
+  assert.equal(mirror.state.fitted, true);
+  await mirror._applyFit();
+  assert.equal(calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length, 0);
+});
+
+test("反复被抢就停手，不跟第三方对刷 setDeviceMetricsOverride", async () => {
+  const { mirror, calls, clearOverride, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+
+  // 对面每轮都把覆盖清掉：失真 → 重发 → 又被清……
+  for (let i = 0; i < 4; i++) {
+    clearOverride();
+    await reread();
+    await mirror._applyFit();
+  }
+  assert.equal(mirror._fitGaveUp, true);
+  assert.match(mirror.state.error, /停止重发/);
+
+  calls.length = 0;
+  clearOverride();
+  await reread();
+  await mirror._applyFit();
+  assert.equal(
+    calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length,
+    0,
+    "停手后不能再发覆盖——无限重发就是把页面按秒 resize，正是引发 403 的那个成因"
+  );
+});
+
+test("重发压根不生效时也算失败，不把基准立在没贴合的尺寸上", async () => {
+  const { mirror, clearOverride, honorOverride, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+
+  // 覆盖从此发不动了（对面清得比我们发得快）。
+  honorOverride(false);
+  clearOverride();
+  for (let i = 0; i < 4; i++) {
+    await reread();
+    await mirror._applyFit();
+  }
+  assert.equal(mirror.state.fitted, false);
+  assert.notDeepEqual(
+    mirror._fitBaseline,
+    { width: WINDOW_VIEWPORT.w, height: WINDOW_VIEWPORT.h },
+    "基准不能立成未贴合的窗口尺寸，否则之后每次判定都通过、fitted 又开始说谎"
+  );
+  assert.equal(mirror._fitGaveUp, true);
+});
+
+test("用户重设尺寸把停手状态放开", async () => {
+  const { mirror, calls, clearOverride, reread } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+  for (let i = 0; i < 4; i++) {
+    clearOverride();
+    await reread();
+    await mirror._applyFit();
+  }
+  assert.equal(mirror._fitGaveUp, true);
+
+  calls.length = 0;
+  mirror.requestFit(1440, 1149, 1);
+  assert.equal(mirror._fitGaveUp, false);
+  await mirror._applyFit();
+  const resent = calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride");
+  assert.equal(resent.length, 1);
+  assert.equal(resent[0].params.width, 1440);
+});
+
+test("换连接/换目标会忘掉贴合缓存（覆盖不可能还在）", async () => {
+  const { mirror } = fitDriftMirror();
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+  mirror._fitGaveUp = true;
+
+  mirror.setTarget("page-2");
+  assert.equal(mirror._appliedFit, null);
+  assert.equal(mirror._fitBaseline, null);
+  assert.equal(mirror._fitGaveUp, false, "换目标后要重新试，不该带着上一只页面的停手状态");
+});
+
+test("回读失败时不立基准，免得把 0×0 当基准无限重发", async () => {
+  const { mirror, calls } = stubMirror({ width: 0, height: 0 });
+  mirror._command = (method, params) => {
+    calls.push({ method, params });
+    if (method === "Runtime.evaluate") return Promise.resolve({ result: {} });
+    return Promise.resolve({ result: {} });
+  };
+  mirror.requestFit(958, 1149, 1);
+  await mirror._applyFit();
+  assert.equal(mirror._fitBaseline, null);
+
+  // 基准为空时不做判定，也就不会误判失真。
+  calls.length = 0;
+  mirror._lastViewportAt = 0;
+  await mirror._refreshViewport();
+  assert.equal(mirror._appliedFit !== null, true);
+  await mirror._applyFit();
+  assert.equal(calls.filter((c) => c.method === "Emulation.setDeviceMetricsOverride").length, 0);
+});
+
 test("无头下截图兜底不退到 fromSurface:false（那是 headful-only，会拿到废图）", async () => {
   const { mirror, calls } = stubMirror();
   mirror.state.headless = true;


### PR DESCRIPTION
Closes #30 · Part of #20

## 定的三件事

**1. 怎么判断覆盖还在？** 记住**贴合当时回读到的视口**当基准，之后只看偏离，阈值 `FIT_DRIFT_PX = 24`。

不能直接和覆盖尺寸比——页面缩放叠在 `setDeviceMetricsOverride` 之上，两者合法地不相等（958 + 90% = 1064，#28 的根因）。24px 的取法：要盖过滚动条出现/消失那十几像素，又要远小于缩放换一档（最小 90%→100% 约 10%）和覆盖被清掉（通常几百像素）。

**2. 重发的代价？** 判定挂在 `_refreshViewport` 既有的 2s 节流里，不新增回读。失真时只**作废缓存**，重发交给 tick 里既有的 `_applyFit`——判定路径上不多开一条发命令的入口。

**重发有上限**（`FIT_DRIFT_LIMIT = 3`）。这条是这票最要紧的地方：真有第三方在抢覆盖时重发赢不了，而无限重发就是把页面按秒 resize，**那正是上一程把账号弹到 403 的成因**。超限就停手，把原因写进 `state.error`（说清多半是并挂了第二个 host），等用户重按贴合或换连接再试。

**3. `state.fitted` 表达什么？** 改成「页面此刻确实处在贴合尺寸」——面板 UI 要的是这个。客户端目前不读它，只有 `state.json` 用于排查。

## 过程中发现的两个死角

- **重发压根不生效**（对面清得比我们发得快）时，基准会被立在**未贴合**的尺寸上，之后每次判定都通过 → 又退回 #30 的原症状，还多了次无效重发。改成这种情况也计入失败、不立基准。
- 上一条的第一版修法把 `_appliedFit` 留在 `want` 上，于是早退分支挡住重试、基准为空又让判定瘫掉，卡在「没贴合、不重试、不报错」。一并作废缓存才收敛。

两个都有测试盯着。

## 触发场景（票里列的都覆盖了）

并挂第二个 host / 真窗口改页面缩放 / 导航后重置 / 崩溃自愈重连——后三种走 `_resetFitCache()`（顺手把六处散落的 `_appliedFit = null` 收成一个方法）。

## 验证

```
node --test "tests/*.test.mjs"   # 39/39（原 31 + 新增 8）
node --check lib/index.js client.js
```

纯本地单测，**没碰真站**（账号 16:08 才解限）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)