### PR TITLE
docs: 修掉面板注释里「默认无头」的陈述

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,10 +13,14 @@
  * 帧来源优先 Page.startScreencast（有变化才推，空闲零开销）；screencast 停推时看门狗
  * 自动回落到 Page.captureScreenshot 定时抓帧（无头下只用 fromSurface:true，见 _pollFrame）。
  *
- * 浏览器默认以**无头**方式拉起（`RECRUIT_BROWSER_HIDDEN=false` 可退回有头）：招聘浏览器
- * 不该抢前景与键盘焦点。实测「离屏有头」（--window-position 到屏幕外）做不到——在 Windows
- * 上创建可见窗口必然激活它，照样抢焦点；而无头下本面板依赖的每条 CDP 能力（screencast、
- * Emulation 贴合、Input 派发、captureScreenshot）与有头零退化。
+ * 拉起浏览器时用有头还是无头**按源分别定**，`RECRUIT_BROWSER_HIDDEN` 只在显式设置时统一
+ * 覆盖（见 `hiddenModeEnabled`）：**BOSS 默认有头**——已实测无头被判成「第三方辅助工具」
+ * 并限制 web 端登录；**猎聘默认无头**——其风控形态一次都没观测过，没有证据支持翻默认，
+ * 而不抢前景与键盘焦点是实打实的好处。
+ *
+ * 「离屏有头」（--window-position 到屏幕外）不是第三个选项：Windows 上创建可见窗口必然
+ * 激活它，照样抢焦点。无头下本面板依赖的每条 CDP 能力（screencast、Emulation 贴合、
+ * Input 派发、captureScreenshot）与有头零退化。
  *
  * boss-cli 固定占用 53470 端口（boss-cli/src/browser/cdp_browser.ts 的
  * REMOTE_DEBUGGING_PORT，可用 BOSS_BROWSER_REMOTE_DEBUGGING_PORT 覆盖），浏览器
@@ -64,11 +68,6 @@ const CHROME_LAUNCH_ARGS = [
   "--disable-extensions"
 ];
 
-/**
- * 隐藏模式（无头）：默认开启——本插件的目的就是让招聘浏览器不抢前景与键盘焦点。
- * 设 `RECRUIT_BROWSER_HIDDEN=false` 退回有头。这个变量是三方（本插件 / boss-cli /
- * liepin-cli）共读的单一来源，各 CLI 自家的变量作为更具体的覆盖项。
- */
 /**
  * 面板自己拉起浏览器时用有头还是无头。
  *


### PR DESCRIPTION
## 为什么

2026-08-19 按证据把默认改成「BOSS 有头、猎聘无头」时，只更新了 `hiddenModeEnabled` 自己的文档块，漏了 `lib/index.js` 里两处：

- **文件头**仍写「浏览器默认以**无头**方式拉起」
- `hiddenModeEnabled` 上方还留着改版前的**旧文档块**（「隐藏模式（无头）：默认开启」），和紧跟其后的新块并存 —— 一个函数两个 JSDoc

代码一直是对的（`DEFAULT_SOURCES` 里 boss `defaultHidden: false`、liepin `true`），`README.md` / `dsh/README.md` / `recruit-daily/references/channels.md` 的说法也都是对的，只有这个文件的注释停在旧版。

留着的风险不是「注释不准」而已：无头正是导致账号被**限制 web 端登录**那次事故的成因，而读代码的人（包括 AI）会按注释推断意图，照着把 BOSS 也调成无头。

## 改了什么

纯注释，零行为变更。文件头改成「按源分别定 + `RECRUIT_BROWSER_HIDDEN` 显式设置才统一覆盖」，保留原有的两条有用结论（「离屏有头」在 Windows 上做不到；无头下 CDP 能力零退化）；删掉那个孤立的旧文档块。

`node --check` 通过，`npm test` 46/46 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)